### PR TITLE
Remove the `shopOrigin` from the appBridge

### DIFF
--- a/src/resources/views/layouts/default.blade.php
+++ b/src/resources/views/layouts/default.blade.php
@@ -31,7 +31,6 @@
                 var createApp = AppBridge.default;
                 var app = createApp({
                     apiKey: "{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}",
-                    shopOrigin: "{{ $shopDomain ?? Auth::user()->name }}",
                     host: "{{ \Request::get('host') }}",
                     forceRedirect: true,
                 });

--- a/tests/Traits/HomeControllerTest.php
+++ b/tests/Traits/HomeControllerTest.php
@@ -24,9 +24,21 @@ class HomeControllerTest extends TestCase
     {
         $shop = factory($this->model)->create(['name' => 'shop-name.myshopify.com']);
 
-        $this->call('get', '/', ['token' => $this->buildToken()])
+        $host = base64_encode($shop->getDomain()->toNative().'/admin');
+        $this->call('get', '/', ['token' => $this->buildToken(), 'host' => $host])
             ->assertOk()
             ->assertSee('apiKey: "'.Util::getShopifyConfig('api_key').'"', false)
-            ->assertSee("shopOrigin: \"{$shop->name}\"", false);
+            ->assertSee("host: \"{$host}\"", false);
+    }
+
+    public function testHomeRouteHostAdmin(): void
+    {
+        $shop = factory($this->model)->create(['name' => 'shop-name.myshopify.com']);
+
+        $host = base64_encode('admin.shopify.com/store/shop-name');
+        $this->call('get', '/', ['token' => $this->buildToken(), 'host' => $host])
+            ->assertOk()
+            ->assertSee('apiKey: "'.Util::getShopifyConfig('api_key').'"', false)
+            ->assertSee("host: \"{$host}\"", false);
     }
 }


### PR DESCRIPTION
Remove the `shopOrigin` from the appBridge config as it throws an "outdated error" when used alongside `host`