### PR TITLE
Fix Host missing from the redirect on blade token auth

### DIFF
--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -301,6 +301,7 @@ class VerifyShopify
             [
                 'shop' => ShopDomain::fromRequest($request)->toNative(),
                 'target' => $target,
+                'host' => $request->get('host'),
             ]
         );
     }


### PR DESCRIPTION
This PR fixes an issue where the host was being dropped in the redirect when using blade templates because of the `token.blade.php` file was only looking for `target` as a param.