### PR TITLE
Bugfix | Pass the host param to the billing return screen.

### DIFF
--- a/src/Http/Middleware/Billable.php
+++ b/src/Http/Middleware/Billable.php
@@ -38,7 +38,10 @@ class Billable
                 // They're not grandfathered in, and there is no charge or charge was declined... redirect to billing
                 return Redirect::route(
                     Util::getShopifyConfig('route_names.billing'),
-                    array_merge($request->input(), ['shop' => $shop->getDomain()->toNative()])
+                    array_merge($request->input(), [
+                        'shop' => $shop->getDomain()->toNative(),
+                        'host' => $request->get('host'),
+                    ])
                 );
             }
         }

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -103,6 +103,7 @@ trait BillingController
             Util::getShopifyConfig('route_names.home'),
             array_merge([
                 'shop' => $shop->getDomain()->toNative(),
+                'host' => $host,
             ], Util::useNativeAppBridge() ? [] : [
                 'host' => $host,
                 'billing' => $result ? 'success' : 'failure',

--- a/tests/Traits/BillingControllerTest.php
+++ b/tests/Traits/BillingControllerTest.php
@@ -121,10 +121,9 @@ class BillingControllerTest extends TestCase
         // Refresh the model
         $shop->refresh();
 
-
         // Assert we've redirected and shop has been updated
         $response->assertRedirect();
-        $this->assertFalse(Str::contains($response->headers->get('Location'), '&host='.$hostValue));
+        $this->assertTrue(Str::contains($response->headers->get('Location'), '&host='.$hostValue));
         $this->assertFalse(Str::contains($response->headers->get('Location'), '&billing=success'));
         $this->assertNotNull($shop->plan);
     }


### PR DESCRIPTION
This PR fixes the issue where using `on_install` with blade engine that AppBridge does not load when it comes back from the billing accept screen because there is no host param that was passed down to it.