### PR TITLE
Pass the host when using the token routes on blade

### DIFF
--- a/src/Macros/TokenUrl.php
+++ b/src/Macros/TokenUrl.php
@@ -15,19 +15,20 @@ abstract class TokenUrl
     /**
      * Return a URL to token path with shop and target.
      *
-     * @param string $route    The route name.
-     * @param array  $params   Additional route params.
-     * @param bool   $absolute Absolute or relative?
+     * @param string $route The route name.
+     * @param array $params Additional route params.
+     * @param bool $absolute Absolute or relative?
      *
      * @return array
      */
-    public function generateParams(string $route, $params = [], bool $absolute = true): array
+    public function generateParams(string $route, array $params = [], bool $absolute = true): array
     {
         return [
             Util::getShopifyConfig('route_names.authenticate.token'),
             [
                 'shop' => ShopDomain::fromRequest(Request::instance())->toNative(),
                 'target' => URL::route($route, $params, $absolute),
+                'host' => $params['host'],
             ],
         ];
     }

--- a/src/Macros/TokenUrl.php
+++ b/src/Macros/TokenUrl.php
@@ -28,7 +28,7 @@ abstract class TokenUrl
             [
                 'shop' => ShopDomain::fromRequest(Request::instance())->toNative(),
                 'target' => URL::route($route, $params, $absolute),
-                'host' => $params['host'],
+                'host' => Request::instance()->get('host'),
             ],
         ];
     }

--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -11,7 +11,8 @@
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function () {
                 var redirectUrl = "{!! $authUrl !!}";
-                if (window.top == window.self) {
+                var normalizedLink;
+                if (window.top === window.self) {
                     // If the current window is the 'parent', change the URL by setting location.href
                     window.top.location.href = redirectUrl;
                 } else {

--- a/src/resources/views/auth/token.blade.php
+++ b/src/resources/views/auth/token.blade.php
@@ -37,8 +37,9 @@
 
     @if(config('shopify-app.appbridge_enabled'))
         <script>
+            const host = new URLSearchParams(location.search).get("host")
             utils.getSessionToken(app).then((token) => {
-                window.location.href = `{!! $target !!}{!! Str::contains($target, '?') ? '&' : '?' !!}token=${token}`;
+                window.location.href = `{!! $target !!}{!! Str::contains($target, '?') ? '&' : '?' !!}token=${token}&host=${host}`;
             });
         </script>
     @endif

--- a/tests/Macros/TokenRedirectTest.php
+++ b/tests/Macros/TokenRedirectTest.php
@@ -17,7 +17,7 @@ class TokenRedirectTest extends TestCase
             // Query Params
             [
                 'shop' => 'example.myshopify.com',
-                'host' => $host
+                'host' => $host,
             ]
         );
         Request::swap($newRequest);

--- a/tests/Macros/TokenRedirectTest.php
+++ b/tests/Macros/TokenRedirectTest.php
@@ -12,10 +12,12 @@ class TokenRedirectTest extends TestCase
     {
         // Setup request
         $currentRequest = Request::instance();
+        $host = base64_encode('example.myshopify.com');
         $newRequest = $currentRequest->duplicate(
             // Query Params
             [
                 'shop' => 'example.myshopify.com',
+                'host' => $host
             ]
         );
         Request::swap($newRequest);
@@ -25,7 +27,7 @@ class TokenRedirectTest extends TestCase
         $location = $response->headers->get('location');
 
         $this->assertSame(
-            'http://localhost/authenticate/token?shop=example.myshopify.com&target=http%3A%2F%2Flocalhost',
+            'http://localhost/authenticate/token?shop=example.myshopify.com&target=http%3A%2F%2Flocalhost&host=ZXhhbXBsZS5teXNob3BpZnkuY29t',
             $location
         );
     }


### PR DESCRIPTION
This should fix https://github.com/Kyon147/laravel-shopify/issues/48 and https://github.com/Kyon147/laravel-shopify/issues/60 as the token redirect is currently not passing over the host.