### PR TITLE
Bugfix | #73 | Double host fix in auth/token

### DIFF
--- a/src/resources/views/auth/token.blade.php
+++ b/src/resources/views/auth/token.blade.php
@@ -39,7 +39,7 @@
         <script>
             const host = new URLSearchParams(location.search).get("host")
             utils.getSessionToken(app).then((token) => {
-                window.location.href = `{!! $target !!}{!! Str::contains($target, '?') ? '&' : '?' !!}token=${token}&host=${host}`;
+                window.location.href = `{!! $target !!}{!! Str::contains($target, '?') ? '&' : '?' !!}token=${token}{{ Str::contains($target, 'host')? '' : '&host=${host}'}}`;
             });
         </script>
     @endif


### PR DESCRIPTION
This fixes an issue in #73 where if host is already passed, we should not append it to the end of the string again.