### PR TITLE
Update the billing redirect to use app bridge.

### DIFF
--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -60,6 +60,7 @@ trait BillingController
             [
                 'url' => $url,
                 'host' => $host,
+                'apiKey' => Util::getShopifyConfig('api_key', ShopDomain::fromNative($request->get('shop'))),
             ]
         );
     }

--- a/src/resources/views/billing/fullpage_redirect.blade.php
+++ b/src/resources/views/billing/fullpage_redirect.blade.php
@@ -5,8 +5,24 @@
         <base target="_top">
 
         <title>Redirecting...</title>
+        <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
+        <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
+        <script type="text/javascript">
+            const redirectUrl = "{!! $url !!}";
 
-        <script type="text/javascript">window.top.location.href = "{!! $url !!}";</script>
+            const AppBridge = window['app-bridge'];
+            const createApp = AppBridge.default;
+            const Redirect = AppBridge.actions.Redirect;
+            const app = createApp({
+                apiKey: "{{ $apiKey }}",
+                host: "{{ $host }}",
+            });
+
+            console.log( 'app', app );
+
+            const redirect = Redirect.create(app);
+            redirect.dispatch(Redirect.Action.REMOTE, redirectUrl);
+        </script>
     </head>
     <body>
     </body>


### PR DESCRIPTION
`window.top` can be blocked by browsers as a popup.  This can stop the billing process from working as it won't move the user over to the admin.xxxx route.

This moves over to the `REMOTE.redirect` method in AppBridge. 