### PR TITLE
401 error for requests without a shop

### DIFF
--- a/src/Exceptions/MissingShopDomainException.php
+++ b/src/Exceptions/MissingShopDomainException.php
@@ -5,6 +5,7 @@ namespace Osiset\ShopifyApp\Exceptions;
 /**
  * Exception for handling a missing shop's myshopify domain.
  */
-class MissingShopDomainException extends BaseException
+class MissingShopDomainException extends HttpException
 {
+    protected $code = 401;
 }


### PR DESCRIPTION
Hello! Otherwise, a 500 error occurs every time clients request an application domain, which clogs the logs.