### PR TITLE
Add leeway for accepting just expired tokens

### DIFF
--- a/src/Objects/Values/SessionToken.php
+++ b/src/Objects/Values/SessionToken.php
@@ -47,7 +47,7 @@ final class SessionToken implements SessionTokenValue
 
     /**
      * Time added to the expiration time, extends the validity period of a session token
-     * 
+     *
      * @var int
      */
     public const LEEWAY_SECONDS = 10;
@@ -228,7 +228,7 @@ final class SessionToken implements SessionTokenValue
 
     /**
      * Get the extended expiration time with leeway of the token.
-     * 
+     *
      * @return Carbon
      */
     public function getLeewayExpiration(): Carbon

--- a/src/Objects/Values/SessionToken.php
+++ b/src/Objects/Values/SessionToken.php
@@ -46,6 +46,13 @@ final class SessionToken implements SessionTokenValue
     public const EXCEPTION_EXPIRED = 'Session token has expired.';
 
     /**
+     * Time added to the expiration time, extends the validity period of a session token
+     * 
+     * @var int
+     */
+    public const LEEWAY_SECONDS = 10;
+
+    /**
      * Token parts.
      *
      * @var array
@@ -220,6 +227,16 @@ final class SessionToken implements SessionTokenValue
     }
 
     /**
+     * Get the extended expiration time with leeway of the token.
+     * 
+     * @return Carbon
+     */
+    public function getLeewayExpiration(): Carbon
+    {
+        return (new Carbon($this->exp))->addSeconds(self::LEEWAY_SECONDS);
+    }
+
+    /**
      * Checks the validity of the signature sent with the token.
      *
      * @throws AssertionFailedException If signature does not match.
@@ -265,7 +282,7 @@ final class SessionToken implements SessionTokenValue
     {
         $now = Carbon::now();
         Assert::thatAll([
-            $now->greaterThan($this->exp),
+            $now->greaterThan($this->getLeewayExpiration()),
             $now->lessThan($this->nbf),
             $now->lessThan($this->iat),
         ])->false(self::EXCEPTION_EXPIRED);

--- a/tests/Objects/Values/SessionTokenTest.php
+++ b/tests/Objects/Values/SessionTokenTest.php
@@ -27,6 +27,31 @@ class SessionTokenTest extends TestCase
         $this->assertSame($this->tokenDefaults['exp'], $st->getExpiration()->unix());
     }
 
+    public function testShouldProcessForExpiredTokenStillInLeewayPeriod(): void
+    {
+        $now = Carbon::now();
+        $token = $this->buildToken(['exp' => (new Carbon($now))->subSeconds(SessionToken::LEEWAY_SECONDS - 2)]);
+        $st = SessionToken::fromNative($token);
+
+        $this->assertInstanceOf(ShopDomainValue::class, $st->getShopDomain());
+        $this->assertTrue(Str::contains($this->tokenDefaults['dest'], $st->getShopDomain()->toNative()));
+
+        $this->assertInstanceOf(SessionIdValue::class, $st->getSessionId());
+        $this->assertSame($this->tokenDefaults['sid'], $st->getSessionId()->toNative());
+
+        $this->assertInstanceOf(Carbon::class, $st->getLeewayExpiration());
+        $this->assertTrue($now->unix() < $st->getLeewayExpiration()->unix());
+        $this->assertTrue($st->getLeewayExpiration()->unix() - $now->unix() < SessionToken::LEEWAY_SECONDS);
+    }
+
+    public function testShouldThrowExceptionForExpiredTokenOutOfLeewayPeriod(): void
+    {
+        $this->expectException(AssertionFailedException::class);
+
+        $token = $this->buildToken(['exp' => Carbon::now()->subSeconds(SessionToken::LEEWAY_SECONDS + 2)]);
+        SessionToken::fromNative($token);
+    }
+
     public function testShouldThrowExceptionForMalformedToken(): void
     {
         $this->expectException(AssertionFailedException::class);


### PR DESCRIPTION
Add a small leeway time for accepting just expired session tokens.

Shopify's official API libraries have already support leeway time: [Python](https://github.com/Shopify/shopify_python_api/pull/609), [PHP](https://github.com/Shopify/shopify-api-php/pull/213),...

Follow the official API libraries, leeway time will be 10 seconds and not configurable.

