### PR TITLE
Update job dispatch method

### DIFF
--- a/src/Actions/AfterAuthorize.php
+++ b/src/Actions/AfterAuthorize.php
@@ -54,7 +54,7 @@ class AfterAuthorize
             $job = Arr::get($config, 'job');
             if (Arr::get($config, 'inline', false)) {
                 // Run this job immediately
-                $job::dispatchNow($shop);
+                $job::dispatchSync($shop);
             } else {
                 // Run later
                 $job::dispatch($shop)

--- a/src/Actions/DispatchScripts.php
+++ b/src/Actions/DispatchScripts.php
@@ -61,7 +61,7 @@ class DispatchScripts
 
         // Run the installer job
         if ($inline) {
-            ($this->jobClass)::dispatchNow(
+            ($this->jobClass)::dispatchSync(
                 $shop->getId(),
                 $scripttags
             );

--- a/src/Actions/DispatchScripts.php
+++ b/src/Actions/DispatchScripts.php
@@ -29,7 +29,7 @@ class DispatchScripts
      * Setup.
      *
      * @param IShopQuery $shopQuery The querier for the shop.
-     * @param string     $jobClass  The job to dispatch.
+     * @param string $jobClass The job to dispatch.
      *
      * @return void
      */
@@ -42,8 +42,8 @@ class DispatchScripts
     /**
      * Execution.
      *
-     * @param ShopIdValue $shopId   The shop ID.
-     * @param bool        $inline   Fire the job inline (now) or queue.
+     * @param ShopIdValue $shopId The shop ID.
+     * @param bool $inline Fire the job inline (now) or queue.
      *
      * @return bool
      */

--- a/src/Actions/DispatchWebhooks.php
+++ b/src/Actions/DispatchWebhooks.php
@@ -61,7 +61,7 @@ class DispatchWebhooks
 
         // Run the installer job
         if ($inline) {
-            ($this->jobClass)::dispatchNow(
+            ($this->jobClass)::dispatchSync(
                 $shop->getId(),
                 $webhooks
             );

--- a/tests/Actions/DispatchScriptsTest.php
+++ b/tests/Actions/DispatchScriptsTest.php
@@ -2,6 +2,7 @@
 
 namespace Osiset\ShopifyApp\Test\Actions;
 
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Osiset\ShopifyApp\Actions\DispatchScripts;
 use Osiset\ShopifyApp\Messaging\Jobs\ScripttagInstaller;
@@ -74,7 +75,7 @@ class DispatchScriptsTest extends TestCase
     public function testRunDispatchNow(): void
     {
         // Fake the queue
-        Queue::fake();
+        Bus::fake([ScripttagInstaller::class]);
 
         // Create the config
         $this->app['config']->set('shopify-app.scripttags', [
@@ -97,7 +98,7 @@ class DispatchScriptsTest extends TestCase
             true // sync
         );
 
-        Queue::assertNotPushed(ScripttagInstaller::class);
+        Bus::assertDispatchedSync(ScripttagInstaller::class);
         $this->assertTrue($result);
     }
 }

--- a/tests/Actions/DispatchWebhooksTest.php
+++ b/tests/Actions/DispatchWebhooksTest.php
@@ -2,6 +2,7 @@
 
 namespace Osiset\ShopifyApp\Test\Actions;
 
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Osiset\ShopifyApp\Actions\DispatchWebhooks;
 use Osiset\ShopifyApp\Messaging\Jobs\WebhookInstaller;
@@ -79,7 +80,7 @@ class DispatchWebhooksTest extends TestCase
     public function testRunDispatchNow(): void
     {
         // Fake the queue
-        Queue::fake();
+        Bus::fake([WebhookInstaller::class]);
 
         // Create the config
         $this->app['config']->set('shopify-app.webhooks', [
@@ -107,7 +108,7 @@ class DispatchWebhooksTest extends TestCase
             true // sync
         );
 
-        Queue::assertNotPushed(WebhookInstaller::class);
+        Bus::assertDispatchedSync(WebhookInstaller::class);
         $this->assertTrue($result);
     }
 }

--- a/tests/Messaging/Jobs/AppUninstalledTest.php
+++ b/tests/Messaging/Jobs/AppUninstalledTest.php
@@ -33,7 +33,7 @@ class AppUninstalledTest extends TestCase
         $this->assertNotEmpty($shop->password);
 
         // Run the job
-        AppUninstalledJob::dispatchNow(
+        AppUninstalledJob::dispatchSync(
             $shop->getDomain()->toNative(),
             json_decode(file_get_contents(__DIR__.'/../../fixtures/app_uninstalled.json'))
         );


### PR DESCRIPTION
As we only support 8/9/10 now for laravel, the jobs we dispatch internally need to be using `dispatchSync` as `dispatchNow` is deprecated.

The tests also need to be updated, as we need to check on the Bus if the job was fired synchronously or not.