### PR TITLE
Feature: Manually map a webhook to a dispatchable class

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,7 +3,7 @@
 # Data taken from https://github.com/osiset/laravel-shopify/graphs/contributors
 # Using `[...document.getElementsByClassName('contrib-person')].map(n => n.getElementsByClassName('avatar')[0].alt).sort().join('\n');`
 
-EClaraLeigh
+ClaraLeigh
 ImgBotApp
 ItsGageH
 Jamesking56

--- a/src/Traits/WebhookController.php
+++ b/src/Traits/WebhookController.php
@@ -26,6 +26,12 @@ trait WebhookController
         $jobClass = Util::getShopifyConfig('job_namespace').str_replace('-', '', ucwords($type, '-')).'Job';
         $jobData = json_decode($request->getContent());
 
+        // If we have manually mapped a class, use that instead
+        $config = Util::getShopifyConfig('webhooks');
+        if (!empty($config[$type]['class'])) {
+            $jobClass = $config[$type]['class'];
+        }
+
         $jobClass::dispatch(
             $request->header('x-shopify-shop-domain'),
             $jobData

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -349,7 +349,13 @@ return [
                 'topic' => env('SHOPIFY_WEBHOOK_2_TOPIC', 'APP_PURCHASES_ONE_TIME_UPDATE'),
                 'address' => env('SHOPIFY_WEBHOOK_2_ADDRESS', 'https://some-app.com/webhook/purchase'),
             ]
-            ...
+            // In certain situations you may wish to map the webhook to a specific class
+            // To do this, change the array to an associative array with a 'class' key
+            'orders-create' => [
+                'topic' => env('SHOPIFY_WEBHOOK_3_TOPIC', 'ORDERS_PAID'),
+                'address' => env('SHOPIFY_WEBHOOK_3_ADDRESS', 'https://some-app.com/webhook/orders-create'),
+                'class' => \App\Shopify\Actions\ExampleAppJob::class
+            ],
         */
     ],
 

--- a/tests/Traits/WebhookControllerTest.php
+++ b/tests/Traits/WebhookControllerTest.php
@@ -103,7 +103,6 @@ class WebhookControllerTest extends TestCase
      * Allow config change to persist when using $this->call()
      *
      * @param $app
-     * @see testHandleWithCustomClassMapping This test uses the config change
      *
      * @return void
      */

--- a/tests/Traits/WebhookControllerTest.php
+++ b/tests/Traits/WebhookControllerTest.php
@@ -4,6 +4,7 @@ namespace Osiset\ShopifyApp\Test\Traits;
 
 use App\Jobs\OrdersCreateJob;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Queue;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 use Osiset\ShopifyApp\Test\TestCase;
@@ -60,5 +61,63 @@ class WebhookControllerTest extends TestCase
             file_get_contents(__DIR__.'/../fixtures/webhook.json')
         );
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testHandleWithCustomClassMapping(): void
+    {
+        // Fake the queue
+        Queue::fake();
+
+        // Extend Job::class into a custom class
+        $shop = factory($this->model)->create(['name' => 'example.myshopify.com']);
+
+        // Mock headers that match Shopify
+        $headers = [
+            'HTTP_CONTENT_TYPE' => 'application/json',
+            'HTTP_X_SHOPIFY_SHOP_DOMAIN' => $shop->name,
+            'HTTP_X_SHOPIFY_HMAC_SHA256' => 'hvTE9wpDzMcDnPEuHWvYZ58ElKn5vHs0LomurfNIuUc=', // Matches fixture data and API secret
+        ];
+
+        // Create a webhook call and pass in our own headers and data
+        $response = $this->call(
+            'post',
+            '/webhook/orders-create-example',
+            [],
+            [],
+            [],
+            $headers,
+            file_get_contents(__DIR__.'/../fixtures/webhook.json')
+        );
+
+        // Check it was created and job was pushed
+        $response->assertStatus(Response::HTTP_CREATED);
+        $response->assertStatus(201);
+
+        Queue::assertPushed(
+            OrdersCreateJob::class
+        );
+    }
+
+    /**
+     * Override the default config
+     * Allow config change to persist when using $this->call()
+     *
+     * @param $app
+     * @see testHandleWithCustomClassMapping This test uses the config change
+     *
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // Update the webhook config to use a custom class
+        $webhooks = Config::get('shopify-app.webhooks');
+        $webhooks['orders-create-example'] = [
+            'topic' => 'ORDERS_PAID',
+            'address' => 'https://some-app.com/webhook/orders-create-example',
+            'class' => OrdersCreateJob::class,
+        ];
+        $app['config']->set('shopify-app.webhooks', $webhooks);
     }
 }


### PR DESCRIPTION
# Description

To allow for different project structures, I wish to allow developers to manually map their webhook to a specific class.

# Changes

To be able to use the feature, you need to change the webhooks config array to use an associate array where the key is the $type variable derived from the wehbook url.

For example:
```
'webhooks' => [
    'orders-create' => [
        'topic' => 'ORDERS_CREATE',
        'address' =>'https://some-app.com/webhook/orders-create',
        'class' => \App\Shopify\Actions\AppUninstalledJob::class
    ]
]
```

Where $type comes from https://some-app.com/webhook/ `orders-create`

# Notes

- This is backwards compatible, you will never need to name the arrays if you don't need to map classes.
- I feel like this config setting could use improvements in other areas, however I currently have no use-case. For example allowing a custom route might be useful for some devs.
- Also I fixed my username in the contrib list