### PR TITLE
Bump default shopify API version

### DIFF
--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -164,7 +164,7 @@ return [
     |
     */
 
-    'api_version' => env('SHOPIFY_API_VERSION', '2022-01'),
+    'api_version' => env('SHOPIFY_API_VERSION', '2023-04'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Services/ApiHelperTest.php
+++ b/tests/Services/ApiHelperTest.php
@@ -42,7 +42,7 @@ class ApiHelperTest extends TestCase
         $this->assertInstanceOf(BasicShopifyAPI::class, $api);
         $this->assertSame(Util::getShopifyConfig('api_secret'), $this->app['config']->get('shopify-app.api_secret'));
         $this->assertSame(Util::getShopifyConfig('api_key'), $this->app['config']->get('shopify-app.api_key'));
-        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2022-01');
+        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2023-04');
     }
 
     public function testSetAndGetApi(): void


### PR DESCRIPTION
### Description
This PR only bumps default shopify API version from outdated `2022-01` to `2023-04`.