### PR TITLE
bugfix: Add missing foreign key for shop/charge relationship

### DIFF
--- a/src/Traits/ShopModel.php
+++ b/src/Traits/ShopModel.php
@@ -82,7 +82,11 @@ trait ShopModel
      */
     public function charges(): HasMany
     {
-        return $this->hasMany(Util::getShopifyConfig('models.charge', Charge::class));
+        return $this->hasMany(
+            Util::getShopifyConfig('models.charge', Charge::class),
+            Util::getShopsTableForeignKey(),
+            'id'
+        );
     }
 
     /**


### PR DESCRIPTION
Minor bug that appears if you have a different model name to Users.

See the inverse of the relationship here:
https://github.com/Kyon147/laravel-shopify/blob/36a8444cd07fe02981b5c9ba814b6f73db02e952/src/Storage/Models/Charge.php#L93