### PR TITLE
Extend session token class api

### DIFF
--- a/src/Objects/Values/SessionToken.php
+++ b/src/Objects/Values/SessionToken.php
@@ -184,8 +184,8 @@ final class SessionToken implements SessionTokenValue
         $this->iss = $body['iss'];
         $this->dest = $body['dest'];
         $this->aud = $body['aud'];
-        $this->sub = $body['dest'];
-        $this->jti = $body['dest'];
+        $this->sub = $body['sub'];
+        $this->jti = $body['jti'];
         $this->sid = SessionId::fromNative($body['sid']);
         $this->exp = new Carbon($body['exp']);
         $this->nbf = new Carbon($body['nbf']);
@@ -224,6 +224,76 @@ final class SessionToken implements SessionTokenValue
     public function getExpiration(): Carbon
     {
         return $this->exp;
+    }
+
+    /**
+     * Get the time before which the token must not be accepted for processing.
+     *
+     * @return \Illuminate\Support\Carbon
+     */
+    public function getNotBefore(): Carbon
+    {
+        return $this->nbf;
+    }
+
+    /**
+     * Get the time at which the token was issued.
+     *
+     * @return \Illuminate\Support\Carbon
+     */
+    public function getIssuedAt(): Carbon
+    {
+        return $this->iat;
+    }
+
+    /**
+     * Get the issuer of the token.
+     *
+     * @return string
+     */
+    public function getIssuer(): string
+    {
+        return $this->iss;
+    }
+
+    /**
+     * Get the destination identity string of the token.
+     *
+     * @return string
+     */
+    public function getDestination(): string
+    {
+        return $this->dest;
+    }
+
+    /**
+     * Get the audience of the token.
+     *
+     * @return string
+     */
+    public function getAudience(): string
+    {
+        return $this->aud;
+    }
+
+    /**
+     * Get the subject of the token.
+     *
+     * @return string
+     */
+    public function getSubject(): string
+    {
+        return $this->sub;
+    }
+
+    /**
+     * Get the JWT id of the token.
+     *
+     * @return string
+     */
+    public function getTokenId(): string
+    {
+        return $this->jti;
     }
 
     /**

--- a/tests/Objects/Values/SessionTokenTest.php
+++ b/tests/Objects/Values/SessionTokenTest.php
@@ -25,6 +25,18 @@ class SessionTokenTest extends TestCase
 
         $this->assertInstanceOf(Carbon::class, $st->getExpiration());
         $this->assertSame($this->tokenDefaults['exp'], $st->getExpiration()->unix());
+
+        $this->assertInstanceOf(Carbon::class, $st->getIssuedAt());
+        $this->assertSame($this->tokenDefaults['iat'], $st->getIssuedAt()->unix());
+
+        $this->assertInstanceOf(Carbon::class, $st->getNotBefore());
+        $this->assertSame($this->tokenDefaults['nbf'], $st->getNotBefore()->unix());
+
+        $this->assertSame($this->tokenDefaults['iss'], $st->getIssuer());
+        $this->assertSame($this->tokenDefaults['dest'], $st->getDestination());
+        $this->assertSame($this->tokenDefaults['aud'], $st->getAudience());
+        $this->assertSame($this->tokenDefaults['sub'], $st->getSubject());
+        $this->assertSame($this->tokenDefaults['jti'], $st->getTokenId());
     }
 
     public function testShouldProcessForExpiredTokenStillInLeewayPeriod(): void


### PR DESCRIPTION
This commit exposes all the JWT claims so that they can be accessed from outside the class. It also fixes a bug where the `dest` claim was incorrectly set on the `sub` and `jti` claim as well.

For my application I'd like to access the `sub` field, but figured it would be best to expose all the other claims as well for completeness.