### PR TITLE
Implement leeway for nbf and iat in session token

### DIFF
--- a/src/Objects/Values/SessionToken.php
+++ b/src/Objects/Values/SessionToken.php
@@ -307,6 +307,26 @@ final class SessionToken implements SessionTokenValue
     }
 
     /**
+     * Get the extended not before time with leeway of the token.
+     *
+     * @return Carbon
+     */
+    public function getLeewayNotBefore(): Carbon
+    {
+        return (new Carbon($this->nbf))->subSeconds(self::LEEWAY_SECONDS);
+    }
+
+    /**
+     * Get the extended issued at time with leeway of the token.
+     *
+     * @return Carbon
+     */
+    public function getLeewayIssuedAt(): Carbon
+    {
+        return (new Carbon($this->iat))->subSeconds(self::LEEWAY_SECONDS);
+    }
+
+    /**
      * Checks the validity of the signature sent with the token.
      *
      * @throws AssertionFailedException If signature does not match.
@@ -353,8 +373,8 @@ final class SessionToken implements SessionTokenValue
         $now = Carbon::now();
         Assert::thatAll([
             $now->greaterThan($this->getLeewayExpiration()),
-            $now->lessThan($this->nbf),
-            $now->lessThan($this->iat),
+            $now->lessThan($this->getLeewayNotBefore()),
+            $now->lessThan($this->getLeewayIssuedAt()),
         ])->false(self::EXCEPTION_EXPIRED);
     }
 }


### PR DESCRIPTION
Lately I've increasingly been running into token expiration errors caused by the not before / issued at being before the server clock time. This PR implements the same leeway as for token expiration for the not before / issued at fields. This seems like a safe approach that Shopify also implements in their official PHP package.