### PR TITLE
Enhancement: Improve BillableMiddleware for SPAs

### DIFF
--- a/src/Http/Middleware/Billable.php
+++ b/src/Http/Middleware/Billable.php
@@ -20,9 +20,9 @@ class Billable
      * @param Request $request The request object.
      * @param Closure $next    The next action.
      *
-     * @return mixed
      * @throws Exception
      *
+     * @return mixed
      */
     public function handle(Request $request, Closure $next)
     {

--- a/src/Http/Middleware/Billable.php
+++ b/src/Http/Middleware/Billable.php
@@ -54,7 +54,7 @@ class Billable
         if ($request->ajax()) {
             return response()->json(
                 ['forceRedirectUrl' => route(...$args)],
-                403
+                402
             );
         }
 

--- a/src/Http/Middleware/Billable.php
+++ b/src/Http/Middleware/Billable.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
 use Osiset\ShopifyApp\Util;
-use RuntimeException;
 
 /**
  * Responsible for ensuring the shop is being billed.

--- a/tests/Http/Middleware/BillableTest.php
+++ b/tests/Http/Middleware/BillableTest.php
@@ -143,7 +143,7 @@ class BillableTest extends TestCase
         $response = $this->runMiddleware(BillableMiddleware::class, $request);
 
         $this->assertFalse($response[0]);
-        $this->assertEquals(403, $response[1]->getStatusCode());
+        $this->assertEquals(402, $response[1]->getStatusCode());
         $this->assertArrayHasKey('forceRedirectUrl', $response[1]->getData(true));
     }
 }

--- a/tests/Http/Middleware/BillableTest.php
+++ b/tests/Http/Middleware/BillableTest.php
@@ -3,12 +3,12 @@
 namespace Osiset\ShopifyApp\Test\Http\Middleware;
 
 use Illuminate\Auth\AuthManager;
+use Illuminate\Http\Request;
 use Osiset\ShopifyApp\Http\Middleware\Billable as BillableMiddleware;
 use Osiset\ShopifyApp\Storage\Models\Charge;
 use Osiset\ShopifyApp\Storage\Models\Plan;
 use Osiset\ShopifyApp\Test\TestCase;
 use Osiset\ShopifyApp\Util;
-use Illuminate\Http\Request;
 
 class BillableTest extends TestCase
 {


### PR DESCRIPTION
### Overview

This PR enhances the `Billable` middleware to provide better support for SPAs by allowing AJAX requests to receive a JSON response with a redirect URL. Currently, `Billable` middleware and the `billing_enabled` configuration have no use for SPAs, & causes confusion which this PR aims to rectify.

### Changes

The updated `Billable` middleware now checks if the incoming request is an AJAX request and, if billing is enabled, returns a `403` status code alongside a JSON response containing a `forceRedirectUrl` field. This field provides a URL to which the SPA can redirect the user. The updated middleware assumes that the `host` parameter is included in the request, which can be easily implemented using an axios interceptor (if using axios on front-end).

By returning a JSON response and a `403` status code, the front-end can now hook into the response interceptor, catch `403` errors, extract the redirect URL from the response, and manage redirection on the front-end. This makes the `Billable` middleware more useful for SPAs.

I added my own middleware in a project I'm working on with React front-end & worked perfectly, so thought it might be useful to improve the original Billable middleware.

**Note** that the wiki would need to be updated if this gets approved/merged.

This should not be a breaking change since `Billable` middleware should not be used anyways for traditional SPAs.
