### PR TITLE
Remove deprecated app bridge utils

### DIFF
--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -7,7 +7,6 @@
         <title>Redirecting...</title>
 
         <script src="https://unpkg.com/@shopify/app-bridge{!! $appBridgeVersion !!}"></script>
-        <script src="https://unpkg.com/@shopify/app-bridge-utils{!! $appBridgeVersion !!}"></script>
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function () {
                 var redirectUrl = "{!! $authUrl !!}";

--- a/src/resources/views/billing/fullpage_redirect.blade.php
+++ b/src/resources/views/billing/fullpage_redirect.blade.php
@@ -6,7 +6,6 @@
 
         <title>Redirecting...</title>
         <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
-        <script src="https://unpkg.com/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
         <script type="text/javascript">
             const redirectUrl = "{!! $url !!}";
 

--- a/src/resources/views/layouts/default.blade.php
+++ b/src/resources/views/layouts/default.blade.php
@@ -19,7 +19,6 @@
 
         @if(\Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_enabled') && \Osiset\ShopifyApp\Util::useNativeAppBridge())
             <script src="{{config('shopify-app.appbridge_cdn_url') ?? 'https://unpkg.com'}}/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
-            <script src="{{config('shopify-app.appbridge_cdn_url') ?? 'https://unpkg.com'}}/@shopify/app-bridge-utils{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script
                 @if(\Osiset\ShopifyApp\Util::getShopifyConfig('turbo_enabled'))
                     data-turbolinks-eval="false"
@@ -27,7 +26,7 @@
             >
                 var AppBridge = window['app-bridge'];
                 var actions = AppBridge.actions;
-                var utils = window['app-bridge-utils'];
+                var utils = AppBridge.utilities;
                 var createApp = AppBridge.default;
                 var app = createApp({
                     apiKey: "{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}",


### PR DESCRIPTION
Shopify has deprecated the standalone app-bridge-utils library and included it into the main app-bridge script. This PR removes the extraneous `<script>` tags and adjusts the usage of the utils package.