### PR TITLE
Include "host" in @sessionToken output

### DIFF
--- a/src/Directives/SessionToken.php
+++ b/src/Directives/SessionToken.php
@@ -2,6 +2,8 @@
 
 namespace Osiset\ShopifyApp\Directives;
 
+use Illuminate\Http\Request;
+
 /**
  * Provides a Blade directive for session tokens.
  */
@@ -14,6 +16,6 @@ class SessionToken
      */
     public function __invoke(): string
     {
-        return '<input type="hidden" class="session-token" name="token" value="" /><input type="hidden" name="host" value="'.str_replace('"', htmlentities('"'), e(\Request::get('host'))).'">';
+        return '<input type="hidden" class="session-token" name="token" value="" /><input type="hidden" name="host" value="'.str_replace('"', htmlentities('"'), e(Request::get('host'))).'">';
     }
 }

--- a/src/Directives/SessionToken.php
+++ b/src/Directives/SessionToken.php
@@ -2,7 +2,7 @@
 
 namespace Osiset\ShopifyApp\Directives;
 
-use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Request;
 
 /**
  * Provides a Blade directive for session tokens.

--- a/src/Directives/SessionToken.php
+++ b/src/Directives/SessionToken.php
@@ -14,6 +14,6 @@ class SessionToken
      */
     public function __invoke(): string
     {
-        return '<input type="hidden" class="session-token" name="token" value="" />';
+        return '<input type="hidden" class="session-token" name="token" value="" /><input type="hidden" name="host" value="'.str_replace('"', htmlentities('"'), e(\Request::get('host'))).'">';
     }
 }

--- a/src/Directives/SessionToken.php
+++ b/src/Directives/SessionToken.php
@@ -2,8 +2,6 @@
 
 namespace Osiset\ShopifyApp\Directives;
 
-use Illuminate\Support\Facades\Request;
-
 /**
  * Provides a Blade directive for session tokens.
  */
@@ -16,6 +14,6 @@ class SessionToken
      */
     public function __invoke(): string
     {
-        return '<input type="hidden" class="session-token" name="token" value="" /><input type="hidden" name="host" value="'.str_replace('"', htmlentities('"'), e(Request::get('host'))).'">';
+        return '<input type="hidden" class="session-token" name="token" value="" /><input type="hidden" name="host" value="'.str_replace('"', htmlentities('"'), e(request('host'))).'">';
     }
 }


### PR DESCRIPTION
Since the `URL::tokenRoute()` helper now includes the `host` parameter, it seems useful to include the same in the `@sessionToken` blade directive output for forms.