### PR TITLE
Include "shop" in @sessionToken output (to fix POS session issue)

### DIFF
--- a/src/Directives/SessionToken.php
+++ b/src/Directives/SessionToken.php
@@ -14,6 +14,6 @@ class SessionToken
      */
     public function __invoke(): string
     {
-        return '<input type="hidden" class="session-token" name="token" value="" /><input type="hidden" name="host" value="'.str_replace('"', htmlentities('"'), e(request('host'))).'">';
+        return '<input type="hidden" class="session-token" name="token" value="" /><input type="hidden" name="host" value="'.str_replace('"', htmlentities('"'), e(request('host'))).'"><input type="hidden" name="shop" value="'.str_replace('"', htmlentities('"'), e(request('shop'))).'">';
     }
 }


### PR DESCRIPTION
Commit a3ba3fb0986fd61d4838bfea2ede561ae8b0043a added "host" to this output and largely fixed an issue I was having (discussed in issue #133 ) with losing the session after the first form submit, however I was still having the same issue when trying to use the app from within Shopify POS. Passing the shop parameter through as well fixed the form submit in Shopify POS.