### PR TITLE
Bump API version to 2023-10

### DIFF
--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -168,7 +168,7 @@ return [
     |
     */
 
-    'api_version' => env('SHOPIFY_API_VERSION', '2023-04'),
+    'api_version' => env('SHOPIFY_API_VERSION', '2023-10'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Services/ApiHelperTest.php
+++ b/tests/Services/ApiHelperTest.php
@@ -42,7 +42,7 @@ class ApiHelperTest extends TestCase
         $this->assertInstanceOf(BasicShopifyAPI::class, $api);
         $this->assertSame(Util::getShopifyConfig('api_secret'), $this->app['config']->get('shopify-app.api_secret'));
         $this->assertSame(Util::getShopifyConfig('api_key'), $this->app['config']->get('shopify-app.api_key'));
-        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2023-04');
+        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2023-10');
     }
 
     public function testSetAndGetApi(): void


### PR DESCRIPTION
This PR only bumps default shopify API version from `2023-04` to `2023-10`.