### PR TITLE
Webhook subscriptions additional fields

### DIFF
--- a/src/Services/ApiHelper.php
+++ b/src/Services/ApiHelper.php
@@ -398,6 +398,18 @@ class ApiHelper implements IApiHelper
             ],
         ];
 
+        if (!empty($payload['metafield_namespaces'])) {
+            $variables['webhookSubscription']['metafieldNamespaces'] = is_array($payload['metafield_namespaces'])
+                ? $payload['metafield_namespaces']
+                : array_map('trim', explode(',', $payload['metafield_namespaces']));
+        }
+
+        if (!empty($payload['include_fields'])) {
+            $variables['webhookSubscription']['includeFields'] = is_array($payload['include_fields'])
+                ? $payload['include_fields']
+                : array_map('trim', explode(',', $payload['include_fields']));
+        }
+
         $response = $this->doRequestGraphQL($query, $variables);
 
         return $response['body'];

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -348,7 +348,12 @@ return [
         /*
             [
                 'topic' => env('SHOPIFY_WEBHOOK_1_TOPIC', 'ORDERS_CREATE'),
-                'address' => env('SHOPIFY_WEBHOOK_1_ADDRESS', 'https://some-app.com/webhook/orders-create')
+                'address' => env('SHOPIFY_WEBHOOK_1_ADDRESS', 'https://some-app.com/webhook/orders-create'),
+                // Optionally you can create an ORDERS_CREATE webhook subscription that includes metafields during serialization
+                // This can be comma-separated string or array
+                'metafield_namespaces' => 'custom,mynamespace',
+                // Or create webhook subscription with fewer resource fields during serialization
+                'include_fields' => 'id,note',
             ], [
                 'topic' => env('SHOPIFY_WEBHOOK_2_TOPIC', 'APP_PURCHASES_ONE_TIME_UPDATE'),
                 'address' => env('SHOPIFY_WEBHOOK_2_ADDRESS', 'https://some-app.com/webhook/purchase'),


### PR DESCRIPTION
Add possibility of adding `includeFields` and `metafieldNamespaces` to webhook subscriptions as documented [here](https://shopify.dev/docs/api/admin-graphql/unstable/mutations/webhookSubscriptionCreate#examples-Create_an_ORDERS_CREATE_webhook_subscription_that_includes_metafields_during_serialization).

```php
'webhooks' => [
    [
        'topic' => 'ORDERS_CREATE',
        'address' => 'https://some-app.com/webhook/orders-create',
        // These can be either comma-separated string or array
        'metafield_namespaces' => 'custom,mynamespace',
        'include_fields' => ['id', 'note'],
    ],
    ...
]
```