### PR TITLE
Update AppUninstalledJob.php

### DIFF
--- a/src/Messaging/Jobs/AppUninstalledJob.php
+++ b/src/Messaging/Jobs/AppUninstalledJob.php
@@ -71,6 +71,9 @@ class AppUninstalledJob implements ShouldQueue
 
         // Get the shop
         $shop = $shopQuery->getByDomain($this->domain);
+        if ( !$shop ) {
+            return true;
+        }
         $shopId = $shop->getId();
 
         // Cancel the current plan


### PR DESCRIPTION
null guard against an invalid shop on uninstall

We had a situation in dev where Shopify sent a bunch of uninstall webhook requests in bursts. This resulted in a state where the $shop returned from getByDomain(...) was null, resulting in an error being thrown. This is a simple guard against that null. I'm not *super* familiar with the package, so if there's cleanup to be done before returning, or if there's a better way to handle this, by all means.