### PR TITLE
Update token handling in Livewire requests (#255)

### DIFF
--- a/src/resources/views/partials/token_handler.blade.php
+++ b/src/resources/views/partials/token_handler.blade.php
@@ -31,13 +31,12 @@
                 window.jQuery.ajaxSettings.headers = { 'Authorization': bearer };
             }
         }
-		
-		if (window.Livewire) {
-            // livewire
-            window.livewire.addHeaders({
-                'Authorization': bearer,
-                'content-type': 'application/json',
-                'X-Requested-With': 'XMLHttpRequest'
+
+        if (window.Livewire) {
+            window.Livewire.hook('request', ({options}) => {
+                options.headers['Authorization'] = `Bearer ${window.sessionToken}`;
+                options.headers['Content-Type'] = 'application/json';
+                options.headers['X-Requested-With'] = 'XMLHttpRequest';
             });
         }
 


### PR DESCRIPTION
The token handling code for Livewire requests in token_handler.blade.php was refactored. Instead of using the addHeaders method, the code now uses a hook to directly add the auth token and other headers into the request options.