### PR TITLE
Remove hardcoded AppBridge CDN URL to make use of CDN defined in config.

### DIFF
--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -6,7 +6,7 @@
 
         <title>Redirecting...</title>
 
-        <script src="https://unpkg.com/@shopify/app-bridge{!! $appBridgeVersion !!}"></script>
+        <script src="{{config('shopify-app.appbridge_cdn_url') ?? 'https://unpkg.com'}}/@shopify/app-bridge{!! $appBridgeVersion !!}"></script>
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function () {
                 var redirectUrl = "{!! $authUrl !!}";

--- a/src/resources/views/billing/fullpage_redirect.blade.php
+++ b/src/resources/views/billing/fullpage_redirect.blade.php
@@ -5,7 +5,7 @@
         <base target="_top">
 
         <title>Redirecting...</title>
-        <script src="https://unpkg.com/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
+        <script src="{{config('shopify-app.appbridge_cdn_url') ?? 'https://unpkg.com'}}/@shopify/app-bridge{{ \Osiset\ShopifyApp\Util::getShopifyConfig('appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
         <script type="text/javascript">
             const redirectUrl = "{!! $url !!}";
 


### PR DESCRIPTION
PR [176](https://github.com/Kyon147/laravel-shopify/pull/176) introduced config for AppBridge CDN.

**auth/fullpage_redirect.blade.php** and **billing/fullpage_redirect.blade.php** still make use of the hardcoded CDN.