### PR TITLE
misc: api version updated to 2024-04

### DIFF
--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -168,7 +168,7 @@ return [
     |
     */
 
-    'api_version' => env('SHOPIFY_API_VERSION', '2024-01'),
+    'api_version' => env('SHOPIFY_API_VERSION', '2024-04'),
 
     /*
     |--------------------------------------------------------------------------
@@ -396,8 +396,7 @@ return [
                 'address' => env('SHOPIFY_WEBHOOK_3_ADDRESS', 'https://some-app.com/webhook/orders-create'),
                 'class' => \App\Shopify\Actions\ExampleAppJob::class
             ],
-        */
-    ],
+        */],
 
     /*
     |--------------------------------------------------------------------------
@@ -416,8 +415,7 @@ return [
                 'display_scope' => env('SHOPIFY_SCRIPTTAG_1_DISPLAY_SCOPE', 'online_store')
             ],
             ...
-        */
-    ],
+        */],
 
     /*
     |--------------------------------------------------------------------------
@@ -441,8 +439,7 @@ return [
                 'job' => env('AFTER_AUTHENTICATE_JOB'), // example: \App\Jobs\AfterAuthorizeJob::class
                 'inline' => env('AFTER_AUTHENTICATE_JOB_INLINE', false) // False = dispatch job for later, true = dispatch immediately
             ],
-        */
-    ],
+        */],
 
     /*
     |--------------------------------------------------------------------------
@@ -551,7 +548,7 @@ return [
          * Cache duration
          */
         'cache_duration' => 12,
-         /*
+        /*
          * At which levels of theme support the use of "theme app extension" is not available
          * and script tags will be installed.
          * Available levels: FULL, PARTIAL, UNSUPPORTED.

--- a/tests/Services/ApiHelperTest.php
+++ b/tests/Services/ApiHelperTest.php
@@ -42,7 +42,7 @@ class ApiHelperTest extends TestCase
         $this->assertInstanceOf(BasicShopifyAPI::class, $api);
         $this->assertSame(Util::getShopifyConfig('api_secret'), $this->app['config']->get('shopify-app.api_secret'));
         $this->assertSame(Util::getShopifyConfig('api_key'), $this->app['config']->get('shopify-app.api_key'));
-        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2024-01');
+        $this->assertSame($this->app['config']->get('shopify-app.api_version'), '2024-04');
     }
 
     public function testSetAndGetApi(): void


### PR DESCRIPTION
Current Shopify API version is 2024-04, so the code has been updated as such.