### PR TITLE
#305 | Try and catch the theme support and any error we keep the theme null 

### DIFF
--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -6,11 +6,11 @@ use Exception;
 use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
 use Osiset\ShopifyApp\Objects\Enums\AuthMode;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel as ThemeSupportLevelEnum;
 use Osiset\ShopifyApp\Objects\Values\AccessToken;
 use Osiset\ShopifyApp\Objects\Values\NullAccessToken;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 use Osiset\ShopifyApp\Objects\Values\ThemeSupportLevel;
-use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel as ThemeSupportLevelEnum;
 use Osiset\ShopifyApp\Util;
 
 /**
@@ -42,16 +42,17 @@ class InstallShop
     /**
      * Setup.
      *
-     * @param IShopQuery  $shopQuery   The querier for the shop.
-     * @param VerifyThemeSupport    $verifyThemeSupport     The action for verify theme support
+     * @param IShopQuery $shopQuery The querier for the shop.
+     * @param VerifyThemeSupport $verifyThemeSupport The action for verify theme support
      *
      * @return void
      */
     public function __construct(
-        IShopQuery $shopQuery,
-        IShopCommand $shopCommand,
+        IShopQuery         $shopQuery,
+        IShopCommand       $shopCommand,
         VerifyThemeSupport $verifyThemeSupport
-    ) {
+    )
+    {
         $this->shopQuery = $shopQuery;
         $this->shopCommand = $shopCommand;
         $this->verifyThemeSupport = $verifyThemeSupport;
@@ -60,8 +61,8 @@ class InstallShop
     /**
      * Execution.
      *
-     * @param ShopDomain  $shopDomain The shop ID.
-     * @param string|null $code       The code from Shopify.
+     * @param ShopDomain $shopDomain The shop ID.
+     * @param string|null $code The code from Shopify.
      *
      * @return array
      */

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -51,8 +51,7 @@ class InstallShop
         IShopQuery         $shopQuery,
         IShopCommand       $shopCommand,
         VerifyThemeSupport $verifyThemeSupport
-    )
-    {
+    ){
         $this->shopQuery = $shopQuery;
         $this->shopCommand = $shopCommand;
         $this->verifyThemeSupport = $verifyThemeSupport;

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -10,6 +10,7 @@ use Osiset\ShopifyApp\Objects\Values\AccessToken;
 use Osiset\ShopifyApp\Objects\Values\NullAccessToken;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
 use Osiset\ShopifyApp\Objects\Values\ThemeSupportLevel;
+use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel as ThemeSupportLevelEnum;
 use Osiset\ShopifyApp\Util;
 
 /**
@@ -100,8 +101,15 @@ class InstallShop
             $data = $apiHelper->getAccessData($code);
             $this->shopCommand->setAccessToken($shop->getId(), AccessToken::fromNative($data['access_token']));
 
-            $themeSupportLevel = call_user_func($this->verifyThemeSupport, $shop->getId());
-            $this->shopCommand->setThemeSupportLevel($shop->getId(), ThemeSupportLevel::fromNative($themeSupportLevel));
+            // Try to get the theme support level, if not, return the default setting
+            try {
+                $themeSupportLevel = call_user_func($this->verifyThemeSupport, $shop->getId());
+                $this->shopCommand->setThemeSupportLevel($shop->getId(), ThemeSupportLevel::fromNative($themeSupportLevel));
+            } catch (Exception $e) {
+                // Just return the default setting which is null
+                $themeSupportLevel = ThemeSupportLevelEnum::NONE;
+            }
+
 
             return [
                 'completed' => true,

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -51,7 +51,7 @@ class InstallShop
         IShopQuery         $shopQuery,
         IShopCommand       $shopCommand,
         VerifyThemeSupport $verifyThemeSupport
-    ){
+    ) {
         $this->shopQuery = $shopQuery;
         $this->shopCommand = $shopCommand;
         $this->verifyThemeSupport = $verifyThemeSupport;

--- a/src/Objects/Enums/ThemeSupportLevel.php
+++ b/src/Objects/Enums/ThemeSupportLevel.php
@@ -32,4 +32,11 @@ class ThemeSupportLevel implements ValueObject
      * @var int
      */
     public const UNSUPPORTED = 2;
+
+    /**
+     * Support level: None.
+     *
+     * @var null
+     */
+    public const NONE = null;
 }


### PR DESCRIPTION
This is a quick fix for the error when installing a store when no theme is selected. This currently affects dev stores but might make it's way into prod if Shopify let you create a store without a theme.