### PR TITLE
Add Subdomain Support

### DIFF
--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -27,6 +27,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sub Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain where Shopify will be accessible from. If the
+    | setting is null, Shopify will reside under the same domain as the
+    | application. Otherwise, this value will be used as the subdomain.
+    |
+    */
+
+    'domain' => env('SHOPIFY_DOMAIN'),
+    
+    /*
+    |--------------------------------------------------------------------------
     | Manual routes
     |--------------------------------------------------------------------------
     |

--- a/src/resources/routes/shopify.php
+++ b/src/resources/routes/shopify.php
@@ -23,7 +23,11 @@ if ($manualRoutes) {
     $manualRoutes = explode(',', $manualRoutes);
 }
 
-Route::group(['prefix' => Util::getShopifyConfig('prefix'), 'middleware' => ['web']], function () use ($manualRoutes) {
+Route::group([
+    'domain' => Util::getShopifyConfig('domain'),
+    'prefix' => Util::getShopifyConfig('prefix'), 
+    'middleware' => ['web']
+], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------
     | Home Route


### PR DESCRIPTION
This update will now support subdomains for Shopify routes if someone wants to add a subdomain prefix.