### PR TITLE
Add subdomain support

### DIFF
--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -27,6 +27,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sub Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain where Shopify will be accessible from. If the
+    | setting is null, Shopify will reside under the same domain as the
+    | application. Otherwise, this value will be used as the subdomain.
+    |
+    */
+
+    'domain' => env('SHOPIFY_DOMAIN'),
+    
+    /*
+    |--------------------------------------------------------------------------
     | Manual routes
     |--------------------------------------------------------------------------
     |

--- a/src/resources/routes/api.php
+++ b/src/resources/routes/api.php
@@ -13,7 +13,10 @@ if ($manualRoutes) {
     $manualRoutes = explode(',', $manualRoutes);
 }
 
-Route::group(['middleware' => ['api']], function () use ($manualRoutes) {
+Route::group([
+    'domain' => Util::getShopifyConfig('domain'),
+    'middleware' => ['api']
+], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------
     | API Routes

--- a/src/resources/routes/shopify.php
+++ b/src/resources/routes/shopify.php
@@ -23,7 +23,11 @@ if ($manualRoutes) {
     $manualRoutes = explode(',', $manualRoutes);
 }
 
-Route::group(['prefix' => Util::getShopifyConfig('prefix'), 'middleware' => ['web']], function () use ($manualRoutes) {
+Route::group([
+    'domain' => Util::getShopifyConfig('domain'),
+    'prefix' => Util::getShopifyConfig('prefix'), 
+    'middleware' => ['web']
+], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------
     | Home Route


### PR DESCRIPTION
This is a simple update to support Shopify routes with a subdomain prefix. It helps users modify and add subdomain support.