### PR TITLE
configure job connections

### DIFF
--- a/src/Actions/AfterAuthorize.php
+++ b/src/Actions/AfterAuthorize.php
@@ -58,6 +58,7 @@ class AfterAuthorize
             } else {
                 // Run later
                 $job::dispatch($shop)
+                    ->onConnection(Util::getShopifyConfig('job_connections')['after_authenticate'])
                     ->onQueue(Util::getShopifyConfig('job_queues')['after_authenticate']);
             }
 

--- a/src/Actions/DispatchScripts.php
+++ b/src/Actions/DispatchScripts.php
@@ -69,7 +69,8 @@ class DispatchScripts
             ($this->jobClass)::dispatch(
                 $shop->getId(),
                 $scripttags
-            )->onQueue(Util::getShopifyConfig('job_queues')['scripttags']);
+            )->onConnection(Util::getShopifyConfig('job_connections')['scripttags'])
+            ->onQueue(Util::getShopifyConfig('job_queues')['scripttags']);
         }
 
         return true;

--- a/src/Actions/DispatchWebhooks.php
+++ b/src/Actions/DispatchWebhooks.php
@@ -69,7 +69,8 @@ class DispatchWebhooks
             ($this->jobClass)::dispatch(
                 $shop->getId(),
                 $webhooks
-            )->onQueue(Util::getShopifyConfig('job_queues')['webhooks']);
+            )->onConnection(Util::getShopifyConfig('job_connections')['webhooks'])
+            ->onQueue(Util::getShopifyConfig('job_queues')['webhooks']);
         }
 
         return true;

--- a/src/Traits/WebhookController.php
+++ b/src/Traits/WebhookController.php
@@ -35,7 +35,8 @@ trait WebhookController
         $jobClass::dispatch(
             $request->header('x-shopify-shop-domain'),
             $jobData
-        )->onQueue(Util::getShopifyConfig('job_queues')['webhooks']);
+        )->onConnection(Util::getShopifyConfig('job_connections')['webhooks'])
+        ->onQueue(Util::getShopifyConfig('job_queues')['webhooks']);
 
         return Response::make('', ResponseResponse::HTTP_CREATED);
     }

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -456,7 +456,21 @@ return [
         'scripttags' => env('SCRIPTTAGS_JOB_QUEUE', null),
         'after_authenticate' => env('AFTER_AUTHENTICATE_JOB_QUEUE', null),
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Job Connections
+    |--------------------------------------------------------------------------
+    |
+    | This option is for setting a specific job connection for webhooks, scripttags
+    | and after_authenticate_job.
+    |
+    */
 
+    'job_connections' => [
+        'webhooks' => env('WEBHOOKS_JOB_CONNECTION', null),
+        'scripttags' => env('SCRIPTTAGS_JOB_CONNECTION', null),
+        'after_authenticate' => env('AFTER_AUTHENTICATE_JOB_CONNECTION', null),
+    ],
     /*
     |--------------------------------------------------------------------------
     | Config API Callback

--- a/tests/Actions/DispatchWebhooksTest.php
+++ b/tests/Actions/DispatchWebhooksTest.php
@@ -77,6 +77,53 @@ class DispatchWebhooksTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testRunDispatchCustomConnection(): void
+    {
+        // Fake the queue
+        Queue::fake();
+
+        // Create the config
+        $this->app['config']->set('shopify-app.webhooks', [
+            [
+                'topic' => 'orders/create',
+                'address' => 'https://localhost/webhooks/orders-create',
+            ],
+            [
+                'topic' => 'app/uninstalled',
+                'address' => 'http://apple.com/uninstall',
+            ],
+        ]);
+
+        // Define the custom job connection
+        $customConnection = 'custom_connection';
+
+        // Set up the configuration
+        $this->app['config']->set('shopify-app.job_connections', [
+            'webhooks' => $customConnection,
+        ]);
+
+        // Setup API stub
+        $this->setApiStub();
+        ApiStub::stubResponses(['get_webhooks']);
+
+        // Create the shop
+        $shop = factory($this->model)->create();
+
+        // Run
+        $result = call_user_func(
+            $this->action,
+            $shop->getId(),
+            false // async
+        );
+
+        // Assert the job was pushed with the correct connection
+        Queue::assertPushed(WebhookInstaller::class, function ($job) use ($customConnection) {
+            return $job->connection === $customConnection;
+        });
+
+        $this->assertTrue($result);
+    }
+
     public function testRunDispatchNow(): void
     {
         // Fake the queue

--- a/tests/Traits/WebhookControllerTest.php
+++ b/tests/Traits/WebhookControllerTest.php
@@ -105,7 +105,7 @@ class WebhookControllerTest extends TestCase
 
         // Extend Job::class into a custom class
         $shop = factory($this->model)->create(['name' => 'example.myshopify.com']);
-       
+
         // Define the custom job connection
         $customConnection = 'custom_connection';
 


### PR DESCRIPTION
### Add Job Connections Configuration

#### Summary

This pull request introduces a new configuration option for setting specific job connections for webhooks, scripttags, and after_authenticate_job.

#### Details

- **Job Connections Configuration**: Added a new `job_connections` array in the configuration file to allow setting custom job connections for:
  - Webhooks
  - Scripttags
  - After Authenticate Job

This change allows developers to define separate job connections for each of these features, enabling better control and customization of their job handling process.

```php
'job_connections' => [
    'webhooks' => env('WEBHOOKS_JOB_CONNECTION', null),
    'scripttags' => env('SCRIPTTAGS_JOB_CONNECTION', null),
    'after_authenticate' => env('AFTER_AUTHENTICATE_JOB_CONNECTION', null),
],
```

#### Environment Variables

To utilize the new job connections, the following environment variables can be set:

- `WEBHOOKS_JOB_CONNECTION`
- `SCRIPTTAGS_JOB_CONNECTION`
- `AFTER_AUTHENTICATE_JOB_CONNECTION`

If these variables are not set, the default job connection will be used.

#### Benefits

- Improved flexibility in handling different job types.
- Enhanced ability to manage and scale job processing according to specific needs.