### PR TITLE
config update for laravel 11

### DIFF
--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -346,6 +346,18 @@ return [
     | Register listeners to the events
     |--------------------------------------------------------------------------
     |
+    | In Laravel version 11 and later, event listeners located in the `App\Listeners`
+    | directory are automatically registered by default. Therefore, manual registration
+    | in this configuration file is unnecessary.
+    |
+    | If you register the listeners manually again here, the listener will be called twice.
+    | 
+    | If you plan to store your listeners in a different directory like `App\Shopify\Listeners`
+    | or within multiple directories, then you should register them here.
+    |
+    | If you are using Laravel version 10 or earlier, then corresponding listeners
+    | must be registered here.
+    |
     */
 
     'listen' => [


### PR DESCRIPTION
### Update Event Listener Registration Documentation for Laravel 11

---

### Description

This PR updates the event listener registration documentation to provide clarity on the changes in Laravel version 11 and later regarding automatic registration of event listeners. Specifically, the following updates have been made:

- Added a detailed comment block explaining that event listeners located in the `App\Listeners` directory are automatically registered in Laravel 11 and later, eliminating the need for manual registration.
- Included a note that if listeners are registered manually in this configuration file, they will be called twice.
- Provided guidance for users who plan to store their listeners in different or multiple directories, specifying that they should register such listeners in this configuration file.
- Added a note for users of Laravel version 10 or earlier, indicating that corresponding listeners must be registered manually in this configuration file.

### Changes

- Updated the comment block in the event listener configuration file with detailed explanations and instructions.

### Documentation

For more details on event discovery in Laravel 11, please refer to the [official documentation](https://laravel.com/docs/11.x/events#event-discovery).

### Testing

No code changes were made, so no testing is required. This PR only updates the documentation within the configuration file.
