### PR TITLE
Pass locale across different steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Its best to:
 
 If you're forking the repository and wish to keep your copy up-to-date with the master, ensure you run this command:
 
-`git remote add upstream git@github.com:osiset/laravel-shopify.git`
+`git remote add upstream git@github.com:Kyon147/laravel-shopify.git`
 
 You can then update by simply running:
 

--- a/src/Http/Middleware/Billable.php
+++ b/src/Http/Middleware/Billable.php
@@ -41,6 +41,7 @@ class Billable
                     array_merge($request->input(), [
                         'shop' => $shop->getDomain()->toNative(),
                         'host' => $request->get('host'),
+                        'locale' => $request->get('locale'),
                     ])
                 );
             }

--- a/src/Http/Middleware/VerifyScopes.php
+++ b/src/Http/Middleware/VerifyScopes.php
@@ -46,6 +46,7 @@ class VerifyScopes
             [
                 'shop' => $shop->getDomain()->toNative(),
                 'host' => $request->get('host'),
+                'locale' => $request->get('locale'),
             ]
         );
     }

--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -305,6 +305,7 @@ class VerifyShopify
                 'shop' => ShopDomain::fromRequest($request)->toNative(),
                 'target' => $target,
                 'host' => $request->get('host'),
+                'locale' => $request->get('locale'),
             ]
         );
     }
@@ -320,7 +321,7 @@ class VerifyShopify
     {
         return Redirect::route(
             Util::getShopifyConfig('route_names.authenticate'),
-            ['shop' => $shopDomain->toNative(), 'host' => request('host')]
+            ['shop' => $shopDomain->toNative(), 'host' => request('host'), 'locale' => request('locale')]
         );
     }
 

--- a/src/Macros/TokenUrl.php
+++ b/src/Macros/TokenUrl.php
@@ -29,6 +29,7 @@ abstract class TokenUrl
                 'shop' => ShopDomain::fromRequest(Request::instance())->toNative(),
                 'target' => URL::route($route, $params, $absolute),
                 'host' => Request::instance()->get('host'),
+                'locale' => Request::instance()->get('locale'),
             ],
         ];
     }

--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -68,6 +68,7 @@ trait AuthController
                     'authUrl' => $result['url'],
                     'host' => $request->get('host'),
                     'shopDomain' => $shopDomain,
+                    'locale' => $request->get('locale'),
                 ]
             );
         } else {
@@ -77,6 +78,7 @@ trait AuthController
                 [
                     'shop' => $shopDomain->toNative(),
                     'host' => $request->get('host'),
+                    'locale' => $request->get('locale'),
                 ]
             );
         }
@@ -100,11 +102,16 @@ trait AuthController
             $params = Util::parseQueryString($query);
             $params['shop'] = $params['shop'] ?? $shopDomain->toNative() ?? '';
             $params['host'] = $request->get('host');
+            $params['locale'] = $request->get('locale');
             unset($params['token']);
 
             $cleanTarget = trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
         } else {
-            $params = ['shop' => $shopDomain->toNative() ?? '', 'host' => $request->get('host')];
+            $params = [
+                'shop' => $shopDomain->toNative() ?? '',
+                'host' => $request->get('host'),
+                'locale' => $request->get('locale'),
+            ];
             $cleanTarget = trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
         }
 

--- a/src/Traits/BillingController.php
+++ b/src/Traits/BillingController.php
@@ -60,6 +60,7 @@ trait BillingController
             [
                 'url' => $url,
                 'host' => $host,
+                'locale' => $request->get('locale'),
                 'apiKey' => Util::getShopifyConfig('api_key', ShopDomain::fromNative($request->get('shop'))),
             ]
         );
@@ -89,6 +90,7 @@ trait BillingController
             return Redirect::route(Util::getShopifyConfig('route_names.home'), [
                 'shop' => $shop->getDomain()->toNative(),
                 'host' => $host,
+                'locale' => $request->get('locale'),
             ]);
         }
         // Activate the plan and save
@@ -99,16 +101,20 @@ trait BillingController
             $host
         );
 
+        $data = [
+            'shop' => $shop->getDomain()->toNative(),
+            'host' => $host,
+            'locale' => $request->get('locale'),
+        ];
+
+        if (!Util::useNativeAppBridge()) {
+            $data['billing'] = $result ? 'success' : 'failure';
+        }
+
         // Go to homepage of app
         return Redirect::route(
             Util::getShopifyConfig('route_names.home'),
-            array_merge([
-                'shop' => $shop->getDomain()->toNative(),
-                'host' => $host,
-            ], Util::useNativeAppBridge() ? [] : [
-                'host' => $host,
-                'billing' => $result ? 'success' : 'failure',
-            ])
+            $data
         )->with(
             $result ? 'success' : 'failure',
             'billing'

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -351,7 +351,7 @@ return [
     | in this configuration file is unnecessary.
     |
     | If you register the listeners manually again here, the listener will be called twice.
-    | 
+    |
     | If you plan to store your listeners in a different directory like `App\Shopify\Listeners`
     | or within multiple directories, then you should register them here.
     |


### PR DESCRIPTION
Locale parameter is lost during internal app navigation (f.e. during authentication) that makes it impossible to apply proper translation