### PR TITLE
Fix authenticate, remove app bridge from auth full redirect page

### DIFF
--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -4,7 +4,6 @@
         <meta charset="utf-8">
         <base target="_top">
         <meta name="shopify-api-key" content="{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}"/>
-        <script src="https://cdn.shopify.com/shopifycloud/app-bridge.js"></script>
 
         <title>Redirecting...</title>
 


### PR DESCRIPTION
The problem was that App Bridge redirected the user back to Shopify before the JavaScript script had a chance to run. 

In theory, after being redirected back to Shopify, our script should have executed, but since we were not yet authenticated at that moment, an error occurred.






