### PR TITLE
Fix 'home' route name in token view

### DIFF
--- a/src/resources/views/auth/token.blade.php
+++ b/src/resources/views/auth/token.blade.php
@@ -43,7 +43,7 @@
 
                 // If shopify is not defined, then we are not in a Shopify context redirect to the homepage as it
                 if (typeof shopify === 'undefined') {
-                    open("{{ route('home') }}", "_self");
+                    open("{{ route(\Osiset\ShopifyApp\Util::getShopifyConfig('route_names.home')) }}", "_self");
                 }
 
                 shopify.idToken().then((token) => {


### PR DESCRIPTION
The problem appears when we customize the name of 'home' route with something else using the config key `route_names.home`, while the view `token.blade.php` retrieves the home route with its default name 'home' .

This PR replaces the 'home' constant with dynamic value from config 'route_names.home'. 