### PR TITLE
Fix existing code linting issues, make CI `PHP Lint` job fail if code style violations are detected

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,4 +31,4 @@ jobs:
           composer install --no-interaction --prefer-dist
 
       - name: Check for code style violation with PHP-CS-Fixer
-        run: vendor/bin/php-cs-fixer fix --diff
+        run: vendor/bin/php-cs-fixer check

--- a/src/Http/Middleware/VerifyScopes.php
+++ b/src/Http/Middleware/VerifyScopes.php
@@ -59,7 +59,7 @@ class VerifyScopes
         $response = Cache::remember(
             $this->cacheKey($shop->getDomain()->toNative()),
             now()->addDay(),
-            fn() => $shop->api()->graph('{
+            fn () => $shop->api()->graph('{
                 currentAppInstallation {
                     accessScopes {
                         handle
@@ -78,7 +78,7 @@ class VerifyScopes
             ];
         }
 
-        Log::error('Fetch current app installation access scopes error: ' . json_encode(data_get($response['body']->toArray(), 'data.currentAppInstallation.userErrors')));
+        Log::error('Fetch current app installation access scopes error: '.json_encode(data_get($response['body']->toArray(), 'data.currentAppInstallation.userErrors')));
 
         return [
             'hasErrors' => true,

--- a/src/resources/routes/api.php
+++ b/src/resources/routes/api.php
@@ -15,7 +15,7 @@ if ($manualRoutes) {
 
 Route::group([
     'domain' => Util::getShopifyConfig('domain'),
-    'middleware' => ['api']
+    'middleware' => ['api'],
 ], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------

--- a/src/resources/routes/shopify.php
+++ b/src/resources/routes/shopify.php
@@ -25,8 +25,8 @@ if ($manualRoutes) {
 
 Route::group([
     'domain' => Util::getShopifyConfig('domain'),
-    'prefix' => Util::getShopifyConfig('prefix'), 
-    'middleware' => ['web']
+    'prefix' => Util::getShopifyConfig('prefix'),
+    'middleware' => ['web'],
 ], function () use ($manualRoutes) {
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Currently there are linting violations, but the `PHP Lint` job is still green/passing.

Most recent example: https://github.com/Kyon147/laravel-shopify/actions/runs/12164298709/job/33925618006

8ca670dab0c2a809f167870cdcb96f7fe858a97e should ensure that the CI job will fail if PHP CS Fixer detects linting violations.

328cc0fec986e51d6720a5ff1d5ff2edde501651 also fixes the 3 existing linting issues.