### PR TITLE
Add api key finder class and related configurations

### DIFF
--- a/src/ApiKeyFinder/CurrentApiKeyFinder.php
+++ b/src/ApiKeyFinder/CurrentApiKeyFinder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Osiset\ShopifyApp\ApiKeyFinder;
+
+use Illuminate\Support\Facades\Config;
+use Osiset\ShopifyApp\Contracts\CurrentApiKeyFinderInterface;
+
+class CurrentApiKeyFinder implements CurrentApiKeyFinderInterface
+{
+    public static function resolve(string $key, $shop = null): ?string
+    {
+        $fullKey = "shopify-app.{$key}";
+        if (! $shop) {
+            // No shop passed, return default
+            return Config::get($fullKey);
+        }
+
+        // Clean the shop domain
+        $shopDomain = $shop instanceof ShopDomainValue ? $shop->toNative() : $shop;
+        $shopDomain = preg_replace('/[^A-Z0-9]/', '', strtoupper(explode('.', $shopDomain)[0]));
+
+        // Try to get env defined for shop, fallback to config value
+        return env(
+            strtoupper($key) . "_" . $shopDomain,
+            Config::get($fullKey)
+        );
+    }
+}

--- a/src/Contracts/CurrentApiKeyFinderInterface.php
+++ b/src/Contracts/CurrentApiKeyFinderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Osiset\ShopifyApp\Contracts;
+
+interface CurrentApiKeyFinderInterface
+{
+    public static function resolve(string $key, $shop = null): ?string;
+}

--- a/src/Util.php
+++ b/src/Util.php
@@ -181,16 +181,24 @@ class Util
             );
         }
 
-        // Check if config API callback is defined
-        if (Str::startsWith($key, 'api')
-            && Arr::exists($config, 'config_api_callback')
-            && is_callable($config['config_api_callback'])) {
-            // It is, use this to get the config value
-            return call_user_func(
-                Arr::get($config, 'config_api_callback'),
-                $key,
-                $shop
-            );
+        // Check if config API callback or class is defined
+        if (Str::startsWith($key, 'api')) {
+            if (
+                Arr::exists($config, 'config_api_callback')
+                && is_callable($config['config_api_callback'])
+            ) {
+                // It is, use this to get the config value
+                return call_user_func(
+                    Arr::get($config, 'config_api_callback'),
+                    $key,
+                    $shop
+                );
+            } else if (
+                Arr::exists($config, 'config_api_class')
+                && class_exists($config['config_api_class'])
+            ) {
+                return $config['config_api_class']::resolve($key, $shop);
+            }
         }
 
         return Arr::get($config, $key);

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -475,6 +475,7 @@ return [
         'scripttags' => env('SCRIPTTAGS_JOB_CONNECTION', null),
         'after_authenticate' => env('AFTER_AUTHENTICATE_JOB_CONNECTION', null),
     ],
+
     /*
     |--------------------------------------------------------------------------
     | Config API Callback
@@ -487,10 +488,33 @@ return [
     | A closure/callable is required.
     | The first argument will be the key string.
     | The second argument will be something to help identify the shop.
+    | 
+    | This will break caching config values because Closures can not be serialized.
+    | Use config_api_class below instead.
     |
     */
 
     'config_api_callback' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Config API Resolver Class
+    |--------------------------------------------------------------------------
+    |
+    | This option can be used to modify what returns when `getConfig('api_*')`
+    | is used. A use-case for this is modifying the return of `api_secret`
+    | or something similar.
+    |
+    | A class name is required
+    | The class must implement Osiset\ShopifyApp\Contracts\CurrentApiKeyFinderInterface
+    | A default class is provided and can be uncommented below.
+    |
+    | config_api_callback will take priority for backwards-compatibility however,
+    | this option is the recommended way because closures can not be serialized.
+    |
+    */
+
+    // 'config_api_class' => Osiset\ShopifyApp\ApiKeyFinder\CurrentApiKeyFinder::class,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces a new mechanism for resolving API keys by implementing a class-based approach. The main changes involve adding a new interface and class for API key resolution, updating the utility function to use this new class, and modifying the configuration file to support this new mechanism.

The driving force behind this PR is that the current method of a callback/closure will break the serialization of the configs so they can not be cached.

### New API Key Resolution Mechanism:

* [`src/ApiKeyFinder/CurrentApiKeyFinder.php`](diffhunk://#diff-402a0fc077b33d8cd47de2310e3ebfec71a3c4776fd910facbfe29d9a7822ce1R1-R28): Added a new class `CurrentApiKeyFinder` that implements the `CurrentApiKeyFinderInterface` to resolve API keys based on the shop domain.
* [`src/Contracts/CurrentApiKeyFinderInterface.php`](diffhunk://#diff-8b7a2da7e6a7371cb25747fe3127a67662840f0df6078bc7f31bff9e41e4c97dR1-R8): Introduced a new interface `CurrentApiKeyFinderInterface` with a method `resolve` for API key resolution.

### Updates to Utility Function:

* [`src/Util.php`](diffhunk://#diff-21d09db944e239ddc517839f6befcb441f0a69afa0580f7be39fa5deedab6eb1L184-R201): Modified the `getShopifyConfig` function to use the new `config_api_class` if defined, allowing for class-based API key resolution.

### Configuration File Changes:

* [`src/resources/config/shopify-app.php`](diffhunk://#diff-4656bc5f1694b5f02c09a12810d37464fa4a613de2a8d89edfd10a94edd74c44R478): Added a new configuration option `config_api_class` to specify the class for API key resolution and updated comments to recommend using this option over `config_api_callback`. [[1]](diffhunk://#diff-4656bc5f1694b5f02c09a12810d37464fa4a613de2a8d89edfd10a94edd74c44R478) [[2]](diffhunk://#diff-4656bc5f1694b5f02c09a12810d37464fa4a613de2a8d89edfd10a94edd74c44R492-R518)