### PR TITLE
Fix: Deprecation warning in PHP 8.4

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -65,7 +65,7 @@ class Util
      *
      * @return mixed
      */
-    public static function parseQueryString(string $queryString, string $delimiter = null): array
+    public static function parseQueryString(string $queryString, ?string $delimiter = null): array
     {
         $commonSeparator = [';' => '/[;]\s*/', ';,' => '/[;,]\s*/', '&' => '/[&]\s*/'];
         $defaultSeparator = '/[&;]\s*/';


### PR DESCRIPTION
When using PHP 8.4, I got the following deprecation warning when running any artisan command:

PHP Deprecated:  Osiset\ShopifyApp\Util::parseQueryString(): Implicitly marking parameter $delimiter as nullable is deprecated, the explicit nullable type must be used instead in .../src/Util.php on line 68

Fix is super simple, just change `string` to `?string` on that line to explicitly declare the parameter can be null.