### PR TITLE
Add fallback redirect button for browser-restricted auto redirection

### DIFF
--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -16,9 +16,15 @@
                 } else {
                     open(redirectUrl, '_top');
                 }
+
+                document.getElementById('redirectBtn').addEventListener('click', function () {
+                   window.top.location.href = redirectUrl;
+                });
+
             });
         </script>
     </head>
     <body>
+     <button id="redirectBtn">Click here to continue</button>
     </body>
 </html>


### PR DESCRIPTION
### Summary
Some browsers block automatic redirection when initiated from an iframe or without a user gesture due to security restrictions (e.g., Chrome's cross-origin navigation policies). This update introduces a fallback button that allows users to manually trigger the redirect if the automatic redirection fails.

### Changes
- Added a `<button>` element to the redirect page.
- Wrapped the redirection logic in a `click` event to ensure compliance with browser security policies.
- Provides a better UX by enabling users to proceed manually when necessary.

### Why This Is Needed
Automatic redirection can fail silently in certain browser contexts, particularly when embedded or without user interaction. The fallback ensures consistent user flow across all environments.

### Testing
Tested in:
- Chrome
- Firefox
- Safari

Redirection now works either automatically or via user interaction when needed.
