### PR TITLE
Fixing a vulnerability related to access to store data.   

### DIFF
--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -101,20 +101,24 @@ class VerifyShopify
             return $next($request);
         }
 
-        if (!Util::useNativeAppBridge()) {
-            $shop = $this->getShopIfAlreadyInstalled($request);
-            $storeResult = !$this->isApiRequest($request) && $shop;
-
-            if ($storeResult) {
-                $this->loginFromShop($shop);
-
-                return $next($request);
-            }
-        }
-
         $tokenSource = $this->getAccessTokenFromRequest($request);
 
         if ($tokenSource === null) {
+            if (!Util::useNativeAppBridge()) {
+                if (str_contains($request->path(), 'api/')) {
+                    throw new HttpException('Access denied.', Response::HTTP_FORBIDDEN);
+                }
+
+                $shop = $this->getShopIfAlreadyInstalled($request);
+                $storeResult = !$this->isApiRequest($request) && $shop;
+
+                if ($storeResult) {
+                    $this->loginFromShop($shop);
+
+                    return $next($request);
+                }
+            }
+
             //Check if there is a store record in the database
             return $this->checkPreviousInstallation($request)
                 // Shop exists, token not available, we need to get one

--- a/src/Messaging/Jobs/AppUninstalledJob.php
+++ b/src/Messaging/Jobs/AppUninstalledJob.php
@@ -72,7 +72,7 @@ class AppUninstalledJob implements ShouldQueue
 
         // Get the shop
         $shop = $shopQuery->getByDomain($this->domain);
-        if ( !$shop ) {
+        if (!$shop) {
             return true;
         }
         $shopId = $shop->getId();

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -588,4 +588,16 @@ return [
     'frontend_engine' => env('SHOPIFY_FRONTEND_ENGINE', 'BLADE'),
 
     'iframe_ancestors' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Forbidden middleware groups
+    |--------------------------------------------------------------------------
+    |
+    | Routes prohibited from being opened in the browser.
+    |
+    */
+    'forbidden_web_middleware_groups' => [
+        'api',
+    ]
 ];

--- a/tests/Traits/ApiControllerTest.php
+++ b/tests/Traits/ApiControllerTest.php
@@ -12,8 +12,8 @@ class ApiControllerTest extends TestCase
         $shop = factory($this->model)->create();
 
         $response = $this->getJson('/api', ['HTTP_X-Shop-Domain' => $shop->name]);
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-        $response->assertExactJson(['error' => 'Session token is invalid.']);
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+        $response->assertExactJson(['error' => 'Access denied.']);
     }
 
     public function testApiWithToken(): void


### PR DESCRIPTION
There is currently an issue:
If you have API routes (which are protected by the VerifyShopify middleware)", any store can access the data of any other store if they want to.
To do this, it's enough to open any API route and add a shop GET parameter with the desired store.

For example:
```
https://***/api/analytics?shop=lorem.myshopify.com
https://***/api/metrics?shop=ipsum.myshopify.com
```
and so on.