### PR TITLE
Bugfix | Fix the webhook connection and queues.

### DIFF
--- a/src/Traits/WebhookController.php
+++ b/src/Traits/WebhookController.php
@@ -32,11 +32,20 @@ trait WebhookController
             $jobClass = $config[$type]['class'];
         }
 
-        $jobClass::dispatch(
+        $dispatch = $jobClass::dispatch(
             $request->header('x-shopify-shop-domain'),
             $jobData
-        )->onConnection(Util::getShopifyConfig('job_connections')['webhooks'])
-        ->onQueue(Util::getShopifyConfig('job_queues')['webhooks']);
+        );
+
+        $connection = Util::getShopifyConfig('job_connections')['webhooks'] ?? null;
+        if ($connection) {
+            $dispatch->onConnection($connection);
+        }
+
+        $queue = Util::getShopifyConfig('job_queues')['webhooks'] ?? null;
+        if ($queue) {
+            $dispatch->onQueue($queue);
+        }
 
         return Response::make('', ResponseResponse::HTTP_CREATED);
     }


### PR DESCRIPTION
Issue:

At the moment we return null if connection and queue are not set in the config which by default that is how it is.

This means that we always force webhooks onto the default queue so that using `onQueue` or `onConnection`are always null from the dispatch.