### PR TITLE
Hotifx | Remove some app example domain

### DIFF
--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -388,16 +388,16 @@ return [
         /*
             [
                 'topic' => env('SHOPIFY_WEBHOOK_1_TOPIC', 'ORDERS_CREATE'),
-                'address' => env('SHOPIFY_WEBHOOK_1_ADDRESS', 'https://some-app.com/webhook/orders-create')
+                'address' => env('SHOPIFY_WEBHOOK_1_ADDRESS', 'https://example.com/webhook/orders-create')
             ], [
                 'topic' => env('SHOPIFY_WEBHOOK_2_TOPIC', 'APP_PURCHASES_ONE_TIME_UPDATE'),
-                'address' => env('SHOPIFY_WEBHOOK_2_ADDRESS', 'https://some-app.com/webhook/purchase'),
+                'address' => env('SHOPIFY_WEBHOOK_2_ADDRESS', 'https://example.com/webhook/purchase'),
             ]
             // In certain situations you may wish to map the webhook to a specific class
             // To do this, change the array to an associative array with a 'class' key
             'orders-create' => [
                 'topic' => env('SHOPIFY_WEBHOOK_3_TOPIC', 'ORDERS_PAID'),
-                'address' => env('SHOPIFY_WEBHOOK_3_ADDRESS', 'https://some-app.com/webhook/orders-create'),
+                'address' => env('SHOPIFY_WEBHOOK_3_ADDRESS', 'https://example.com/webhook/orders-create'),
                 'class' => \App\Shopify\Actions\ExampleAppJob::class
             ],
         */],
@@ -414,7 +414,7 @@ return [
     'scripttags' => [
         /*
             [
-                'src' => env('SHOPIFY_SCRIPTTAG_1_SRC', 'https://some-app.com/some-controller/js-method-response'),
+                'src' => env('SHOPIFY_SCRIPTTAG_1_SRC', 'https://example.com/some-controller/js-method-response'),
                 'event' => env('SHOPIFY_SCRIPTTAG_1_EVENT', 'onload'),
                 'display_scope' => env('SHOPIFY_SCRIPTTAG_1_DISPLAY_SCOPE', 'online_store')
             ],

--- a/tests/Traits/WebhookControllerTest.php
+++ b/tests/Traits/WebhookControllerTest.php
@@ -159,7 +159,7 @@ class WebhookControllerTest extends TestCase
         $webhooks = Config::get('shopify-app.webhooks');
         $webhooks['orders-create-example'] = [
             'topic' => 'ORDERS_PAID',
-            'address' => 'https://some-app.com/webhook/orders-create-example',
+            'address' => 'https://example.com/webhook/orders-create-example',
             'class' => OrdersCreateJob::class,
         ];
         $app['config']->set('shopify-app.webhooks', $webhooks);


### PR DESCRIPTION
Shopify have gotten in touch to flag.

This repository makes references to the domain “some-app[.]com” which appears to be a spam site. We’ve received several recent reports indicating that the placeholder URL within the repo https://some-app.com/some-controller/js-m is redirecting to malicious content which has been flagged by Google. 

Moved the examples over example.com which is safer.