### PR TITLE
Enhancement: Improve BillableMiddleware for SPAs | revive PR #167

### DIFF
--- a/src/Http/Middleware/Billable.php
+++ b/src/Http/Middleware/Billable.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
 use Osiset\ShopifyApp\Util;
-use RuntimeException;
 
 /**
  * Responsible for ensuring the shop is being billed.
@@ -19,35 +18,47 @@ class Billable
      * Checks if a shop has paid for access.
      *
      * @param Request $request The request object.
-     * @param Closure $next The next action.
+     * @param Closure $next    The next action.
      *
-     *@throws Exception
+     * @throws Exception
      *
      * @return mixed
      */
     public function handle(Request $request, Closure $next)
     {
-        if (!Util::isMPAApplication()) {
-            throw new RuntimeException('You cannot use Billable middleware with SPA mode');
+        if (Util::getShopifyConfig('billing_enabled') !== true) {
+            return $next($request);
         }
 
-        if (Util::getShopifyConfig('billing_enabled') === true) {
-            /** @var $shop IShopModel */
-            $shop = auth()->user();
-            if (!$shop->plan && !$shop->isFreemium() && !$shop->isGrandfathered()) {
-                // They're not grandfathered in, and there is no charge or charge was declined... redirect to billing
-                return Redirect::route(
-                    Util::getShopifyConfig('route_names.billing'),
-                    array_merge($request->input(), [
-                        'shop' => $shop->getDomain()->toNative(),
-                        'host' => $request->get('host'),
-                        'locale' => $request->get('locale'),
-                    ])
-                );
-            }
+        // Proceed if we are on SPA mode & it's a non ajax request
+        if (!Util::isMPAApplication() && ! $request->ajax()) {
+            return $next($request);
         }
 
-        // Move on, everything's fine
-        return $next($request);
+        /** @var $shop IShopModel */
+        $shop = auth()->user();
+
+        // if shop has plan or is on freemium or is grandfathered then move on with request
+        if (! $shop || $shop->plan || $shop->isFreemium() || $shop->isGrandfathered()) {
+            return $next($request);
+        }
+
+        $args = [
+            Util::getShopifyConfig('route_names.billing'),
+            array_merge($request->input(), [
+                'shop' => $shop->getDomain()->toNative(),
+                'host' => $request->get('host'),
+                'locale' => $request->get('locale'),
+            ]),
+        ];
+
+        if ($request->ajax()) {
+            return response()->json(
+                ['forceRedirectUrl' => route(...$args)],
+                402
+            );
+        }
+
+        return Redirect::route(...$args);
     }
 }

--- a/tests/Http/Middleware/BillableTest.php
+++ b/tests/Http/Middleware/BillableTest.php
@@ -3,6 +3,7 @@
 namespace Osiset\ShopifyApp\Test\Http\Middleware;
 
 use Illuminate\Auth\AuthManager;
+use Illuminate\Http\Request;
 use Osiset\ShopifyApp\Http\Middleware\Billable as BillableMiddleware;
 use Osiset\ShopifyApp\Storage\Models\Charge;
 use Osiset\ShopifyApp\Storage\Models\Plan;
@@ -99,5 +100,50 @@ class BillableTest extends TestCase
         $result = $this->runMiddleware(BillableMiddleware::class);
 
         $this->assertTrue($result[0]);
+    }
+
+    public function testNoNativeAppBridgeAndNoAjaxRequest(): void
+    {
+        $plan = factory(Util::getShopifyConfig('models.plan', Plan::class))->states('type_recurring')->create();
+        $shop = factory($this->model)->create(['plan_id' => $plan->getId()->toNative()]);
+
+        factory(Util::getShopifyConfig('models.charge', Charge::class))->states('type_recurring')->create(
+            [
+                'plan_id' => $plan->getId()->toNative(),
+                'user_id' => $shop->getId()->toNative(),
+            ]
+        );
+
+        $this->auth->login($shop);
+        $this->app['config']->set('shopify-app.billing_enabled', true);
+        $this->app['config']->set('shopify-app.frontend_engine', 'REACT');
+
+        $request = Request::create('/test', 'GET');
+
+        $this->assertFalse($request->ajax());
+
+        $result = $this->runMiddleware(BillableMiddleware::class, $request);
+
+        $this->assertTrue($result[0]);
+    }
+
+    public function testAjaxRequest(): void
+    {
+        $shop = factory($this->model)->create();
+
+        $this->auth->login($shop);
+        $this->app['config']->set('shopify-app.billing_enabled', true);
+        $this->app['config']->set('shopify-app.frontend_engine', 'REACT');
+
+        $request = Request::create('/test', 'GET');
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $this->assertTrue($request->ajax());
+
+        $response = $this->runMiddleware(BillableMiddleware::class, $request);
+
+        $this->assertFalse($response[0]);
+        $this->assertEquals(402, $response[1]->getStatusCode());
+        $this->assertArrayHasKey('forceRedirectUrl', $response[1]->getData(true));
     }
 }


### PR DESCRIPTION
### Note: This is not my original work, its a copy of https://github.com/Kyon147/laravel-shopify/pull/167 by @ggelashvili

### Overview
This PR enhances the `Billable` middleware to provide better support for SPAs by allowing AJAX requests to receive a JSON response with a redirect URL. Currently, `Billable` middleware and the `billing_enabled` configuration have no use for SPAs, & causes confusion which this PR aims to rectify.

### Changes
The updated `Billable` middleware now checks if the incoming request is an AJAX request and, if billing is enabled, returns a `402` status code alongside a JSON response containing a `forceRedirectUrl` field. This field provides a URL to which the SPA can redirect the user. The updated middleware assumes that the `host` parameter is included in the request, which can be easily implemented using an axios interceptor (if using axios on front-end).

By returning a JSON response and a `402` status code, the front-end can now hook into the response interceptor, catch `402` errors, extract the redirect URL from the response, and manage redirection on the front-end. This makes the `Billable` middleware more useful for SPAs.

I added my own middleware in a project I'm working on with React front-end & worked perfectly, so thought it might be useful to improve the original Billable middleware.

Note that the wiki would need to be updated if this gets approved/merged.

This should not be a breaking change since `Billable` middleware should not be used anyways for traditional SPAs.