### PR TITLE
Fix for checkout ui session tokens

### DIFF
--- a/src/Objects/Values/SessionToken.php
+++ b/src/Objects/Values/SessionToken.php
@@ -398,7 +398,7 @@ final class SessionToken implements SessionTokenValue
 
     protected function determineTokenSource(array $body): int
     {
-        if (!isset($body['iss']) && !isset($body['sid'])) {
+        if (!isset($body['sid'])) {
             return SessionTokenSource::CHECKOUT_EXTENSION;
         }
 


### PR DESCRIPTION
This is a quick fix for an issue discussed on PR #329 

It appears Shopify now issues the `iss` field on Checkout UI session tokens, breaking the current `determineTokenSource` method.

This PR removes the `iss` field check and relys solely on the presence of the `sid` field to determine if the SessionToken comes from the app or checkout ui.

According to the Shopify documentation, they define the sid as:
`sid: A unique session ID per user and app.`
[Shopify docs](https://shopify.dev/docs/apps/build/authentication-authorization/session-tokens)

Therefore, it makes sense that a sid wouldn't be issued for a checkout/account UI extension as there's no authenticated Shopify user using the app.