### PR TITLE
Add app bridge to full page redirect

### DIFF
--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <base target="_top">
         <meta name="shopify-api-key" content="{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}"/>
+        <script src="https://cdn.shopify.com/shopifycloud/app-bridge.js"></script>
 
         <title>Redirecting...</title>
 


### PR DESCRIPTION
This pull request makes a minor update to the authentication redirect view by including the Shopify App Bridge library. This fixes https://github.com/Kyon147/laravel-shopify/issues/453 (blank page on install or when updating api scopes for non-managed flow).

* Added a `<script>` tag to load the Shopify App Bridge library from the CDN in `src/resources/views/auth/fullpage_redirect.blade.php`.