### PR TITLE
Add fullpage redirect condition, to not load appbridge on the auth flow.

### DIFF
--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -4,7 +4,9 @@
         <meta charset="utf-8">
         <base target="_top">
         <meta name="shopify-api-key" content="{{ \Osiset\ShopifyApp\Util::getShopifyConfig('api_key', $shopDomain ?? Auth::user()->name ) }}"/>
-        <script src="https://cdn.shopify.com/shopifycloud/app-bridge.js"></script>
+        @if(request()->header('sec-fetch-dest') === 'iframe')
+            <script src="https://cdn.shopify.com/shopifycloud/app-bridge.js"></script>
+        @endif
 
         <title>Redirecting...</title>
 


### PR DESCRIPTION
Adds a check to use appbridge when inside the iframe, but not during the fullepage redirect outside the frame for the initial install.

Solve was done by jackthedev ✨ on issue https://github.com/Kyon147/laravel-shopify/issues/456