### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-json": "*",
         "funeralzone/valueobjects": "^0.5",
         "jenssegers/agent": "^2.6",
-        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "gnikyt/basic-shopify-api": "^9.0 || ^10.0 || ^11.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

This PR adds Laravel 13 support by updating the `laravel/framework` constraint in composer.json.

## Changes

- Updated `composer.json`: Added `|| ^13.0` to the `laravel/framework` requirement

## Before
```json
"laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
```

## After
```json
"laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0"
```

## Testing

- Tested in a production Laravel application upgraded to Laravel 13.0
- No code changes required - Laravel 13 is backwards compatible with the existing codebase
- All existing functionality works as expected

## Notes

- Laravel 13 was released on March 17, 2026
- This is a constraint-only update, no breaking changes in the package code