### PR TITLE
Add Support for Laravel 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - '10.0'
           - '11.0.3'
           - '12.0'
+          - '13.0'
         exclude:
           - php: '8.0'
             laravel: '9.0'
@@ -44,6 +45,10 @@ jobs:
             laravel: '9.0'
           - php: '8.4'
             laravel: '12.0'
+          - php: '8.1'
+            laravel: '13.0'
+          - php: '8.2'
+            laravel: '13.0'
         include:
           - php: '8.0'
             laravel: '9.39.0'

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-json": "*",
         "funeralzone/valueobjects": "^0.5",
         "jenssegers/agent": "^2.6",
-        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "gnikyt/basic-shopify-api": "^9.0 || ^10.0 || ^11.0"
     },
     "require-dev": {

--- a/tests/Http/Middleware/VerifyScopesTest.php
+++ b/tests/Http/Middleware/VerifyScopesTest.php
@@ -35,7 +35,8 @@ class VerifyScopesTest extends TestCase
         $request = Request::create('/', 'GET', ['shop' => $shop->getDomain()->toNative()]);
 
         $middleware = new VerifyScopesMiddleware();
-        $result = $middleware->handle($request, function () {});
+        $result = $middleware->handle($request, function () {
+        });
 
         $this->assertEquals(302, $result->getStatusCode());
     }
@@ -53,7 +54,8 @@ class VerifyScopesTest extends TestCase
         $request = Request::create('/', 'GET', ['shop' => $shop->getDomain()->toNative()]);
 
         $middleware = new VerifyScopesMiddleware();
-        $result = $middleware->handle($request, function () {});
+        $result = $middleware->handle($request, function () {
+        });
 
         $this->assertEquals($result, null);
     }
@@ -71,7 +73,8 @@ class VerifyScopesTest extends TestCase
         $request = Request::create('/', 'GET', ['shop' => $shop->getDomain()->toNative()]);
 
         $middleware = new VerifyScopesMiddleware();
-        $result = $middleware->handle($request, function () {});
+        $result = $middleware->handle($request, function () {
+        });
 
         $this->assertEquals($result, null);
     }


### PR DESCRIPTION
This PR adds support for Laravel 13 in `composer.json` and also updates the test matrix in `ci.yml` to include it too. The min PHP version for L13 is PHP83, so we're excluding testing it on PHP81 and PHP82.

(This does follow on from https://github.com/Kyon147/laravel-shopify/pull/469, but adds the needed changes to ci.yml, unfortunately I can't edit that branch). 