### PR TITLE
Add Laravel Boost Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,10 @@ Its best to:
 
 ## Misc
 
+### Laravel Boost (`resources/boost/`)
+
+The `resources/boost/` directory holds **consumer-facing** [Laravel Boost](https://laravel.com/docs/13.x/boost#third-party-package-ai-guidelines) guidelines and Agent Skills for teams building **host applications** that install this package—not for day-to-day package test maintenance. When you change public integration behavior (config keys, middleware contracts, token lifecycle, webhook flow), review and update those files so Boost stays accurate.
+
 ### Adding upstream
 
 If you're forking the repository and wish to keep your copy up-to-date with the master, ensure you run this command:

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,15 @@
+## kyon147/laravel-shopify (host app)
+
+- This Composer package adds **Shopify embedded / custom app** support to **your** Laravel app: OAuth, session handling, billing helpers, webhooks, and related tooling. After install: `php artisan vendor:publish --tag=shopify-config`, set documented `SHOPIFY_*` keys in `.env`, run migrations, and wire **your** shop/user model to the package contract + trait.
+- **Agents:** use **published** `config/shopify-app.php` and documented env keys only. Do not weaken HMAC, session token, or webhook verification in app code to “fix” auth.
+- **Where to work:** **your** `.env`, `config/shopify-app.php`, `routes/*.php`, models, and middleware registration. Package source under `vendor/kyon147/laravel-shopify` is **read-only reference** (e.g. default routes in `src/resources/routes/`, middleware in `src/Http/`).
+
+### Skill routing (activate the matching skill)
+
+| Task in the **host app** | Skill |
+| --- | --- |
+| OAuth, embedded auth, `verify.shopify`, session token / App Bridge, protecting routes | `shopify-app-authentication` |
+| Subscriptions, charges, `billable` middleware, plan URLs | `shopify-app-billing` |
+| Webhook topics, HMAC verification, uninstall / compliance jobs, queues | `shopify-app-webhooks` |
+| PHPUnit / Pest / HTTP tests for **your** app using the package | `shopify-app-integration-testing` |
+| Expiring offline tokens, refresh skew, migrations, `APP_KEY`, refresh failures | `shopify-app-offline-access-tokens` |

--- a/resources/boost/skills/shopify-app-authentication/SKILL.md
+++ b/resources/boost/skills/shopify-app-authentication/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: shopify-app-authentication
+description: OAuth, session tokens, and route protection for a Laravel Shopify app using kyon147/laravel-shopify.
+---
+
+## When to use
+
+You are in a **host Laravel application** that depends on `kyon147/laravel-shopify` and you are configuring or debugging **authentication**: first install, OAuth redirect loop, embedded admin vs full-page auth, session token / App Bridge, or protecting **your** routes with package middleware.
+
+## Key setup (in your app)
+
+1. Publish config: `php artisan vendor:publish --tag=shopify-config` (adjust tag if your install docs differ).
+2. Set env keys from the package README and **published** `config/shopify-app.php` — at minimum `SHOPIFY_API_KEY`, `SHOPIFY_API_SECRET`, `SHOPIFY_API_SCOPES` (maps to `api_scopes`), and URLs that match Shopify Partners / `APP_URL`.
+3. Run package migrations (or publish `shopify-migrations` if you use `SHOPIFY_MANUAL_MIGRATIONS`).
+4. Your **shop** model (often `User`) should implement `Osiset\ShopifyApp\Contracts\ShopModel` and use `Osiset\ShopifyApp\Traits\ShopModel` — see package `src/Contracts/ShopModel.php` and `src/Traits/ShopModel.php` as reference only.
+
+## Middleware (attach in your routes)
+
+The package registers route middleware aliases (see `ShopifyAppProvider::bootMiddlewares()`):
+
+| Alias | Purpose |
+| --- | --- |
+| `verify.shopify` | Ensure the shop is authenticated for **your** protected routes. |
+| `verify.scopes` | Re-check granted scopes when needed. |
+| `auth.proxy` | App proxy requests from Shopify. |
+| `auth.webhook` | Webhook HMAC verification (typically on webhook routes). |
+| `billable` | Billing gate (see billing skill). |
+
+`IframeProtection` is pushed onto the `web` middleware group by the package.
+
+Example (conceptual): wrap **your** app routes in a group using `middleware(['verify.shopify'])` (and `verify.scopes` if you split concerns).
+
+## How pieces fit together (reference)
+
+- High-level auth flow: package `AuthController`, `Actions/InstallShop`, `Actions/AuthenticateShop` — **do not edit vendor**; override behavior via config, listeners, or **your** routes if the package documents extension points.
+- SPA / session token: package views under `src/resources/views/auth/` — use or replace in **your** app as documented, not by patching the package.
+
+## Do / Don’t
+
+- **Do** keep `APP_URL`, Shopify app URLs, and redirect URLs aligned with Partners dashboard settings.
+- **Do** use the published config keys the package defines; avoid inventing parallel “secret” env names.
+- **Don’t** disable HMAC verification, session checks, or related middleware in config or custom middleware to bypass errors.

--- a/resources/boost/skills/shopify-app-billing/SKILL.md
+++ b/resources/boost/skills/shopify-app-billing/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: shopify-app-billing
+description: Subscriptions, charges, and billable routes for a Laravel Shopify app using kyon147/laravel-shopify.
+---
+
+## When to use
+
+You are in a **host Laravel application** with `kyon147/laravel-shopify` and you need **billing**: recurring or one-time charges, plan selection URLs, or gating **your** controllers until the shop has an active plan.
+
+## Configuration (your published `shopify-app.php`)
+
+Enable and tune billing via env + config keys such as:
+
+- `SHOPIFY_BILLING_ENABLED` → `billing_enabled`
+- `SHOPIFY_BILLING_FREEMIUM_ENABLED` → `billing_freemium_enabled`
+- `SHOPIFY_BILLING_REDIRECT` → `billing_redirect` (where users land for the billing flow)
+
+Confirm `route_names` for `billing`, `billing.process`, and `billing.usage_charge` if you override route names to avoid collisions with **your** app.
+
+## Protecting routes
+
+Apply the `billable` middleware (alias for `Osiset\ShopifyApp\Http\Middleware\Billable`) to **your** route groups or controllers that should only run for shops with a valid charge/plan per package rules.
+
+Combine with `verify.shopify` when the route also requires an authenticated shop session.
+
+## Extending billing in the app (don’t edit vendor)
+
+- Package `BillingController` and `Traits/BillingController` show how billing endpoints are structured — **extend or wrap** from **your** `App\Http\Controllers` if you need custom UX, keeping the package’s config and charge flow intact.
+- API calls for plans/charges typically go through the shop model’s integration with `apiHelper()` and related storage — reference `src/Services/ApiHelper.php` and models under `src/Storage/Models/` in vendor for behavior, implement app-specific logic in **your** namespaces.
+
+## Do / Don’t
+
+- **Do** test the full redirect loop (plan URL → Shopify approval → callback) in a dev store.
+- **Don’t** bypass `billable` or charge checks in production routes for convenience.

--- a/resources/boost/skills/shopify-app-integration-testing/SKILL.md
+++ b/resources/boost/skills/shopify-app-integration-testing/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: shopify-app-integration-testing
+description: Writing application-level tests for a Laravel Shopify app that uses kyon147/laravel-shopify.
+---
+
+## When to use
+
+You are writing **PHPUnit**, **Pest**, or **HTTP** tests in **your** Laravel application (not in the package repo) that exercise routes or services integrated with `kyon147/laravel-shopify`.
+
+## What to test
+
+- **Your** routes behind `verify.shopify`, `billable`, or other package middleware: use Laravel’s HTTP testing helpers, acting as the authenticated shop user/model your app uses, and set session or headers the middleware expects per your app’s auth mode.
+- **Your** controllers, jobs, and listeners that react to Shopify-related events or stored shop state.
+
+## Faking Shopify and HTTP
+
+- Fake HTTP to Shopify at **your application boundary** — e.g. `Http::fake()` for outgoing Admin API calls, or test doubles for services **you** own — instead of relying on JSON fixtures from the **package’s** internal test suite (those exist only for developing `laravel-shopify` itself).
+- Keep tests deterministic: stub time if you assert token expiry windows.
+
+## Common pitfalls
+
+- **`APP_URL`** mismatch with route generation or redirect assertions in tests.
+- **Shop domain / shop record** missing on the user model when middleware expects it.
+- **`APP_KEY`** missing or changing between runs when encrypted casts or session encryption affect outcomes.
+
+## Do / Don’t
+
+- **Do** prefer testing **your** app’s public HTTP surface and job dispatch over reaching into vendor classes.
+- **Don’t** copy package-internal fixture files into your app unless you are explicitly mirroring a contract you own; prefer fakes at the HTTP client or service level.

--- a/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
+++ b/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: shopify-app-offline-access-tokens
+description: Expiring offline access tokens, migrations, and refresh behavior for kyon147/laravel-shopify in a host Laravel app.
+---
+
+## When to use
+
+You are enabling or operating **Shopify expiring offline access tokens** in **your** Laravel app: env toggles, database columns, model casts, production refresh failures, or API calls that should trigger transparent refresh.
+
+## Configuration (your published `shopify-app.php`)
+
+- `SHOPIFY_EXPIRING_OFFLINE_TOKENS` → `expiring_offline_tokens` — when `true`, new offline exchanges use refresh-token rotation per Shopify’s model.
+- `SHOPIFY_OFFLINE_ACCESS_TOKEN_REFRESH_SKEW` → `offline_access_token_refresh_skew_seconds` — refresh this many seconds **before** access token expiry.
+
+Read the package README for policy notes (e.g. public apps after Shopify’s cutoff dates).
+
+## Database (your migrated schema)
+
+Run package migrations so the shop table (from `Osiset\ShopifyApp\Util::getShopsTable()`, often `users`) includes:
+
+- `shopify_offline_refresh_token`
+- `shopify_offline_access_token_expires_at`
+- `shopify_offline_refresh_token_expires_at`
+
+If you override `$casts` on **your** shop model, merge with the package trait’s casts rather than dropping encrypted/datetime casts the package expects.
+
+## Runtime behavior (reference)
+
+- Token refresh is coordinated through `ApiHelper` and `OfflineAccessTokenRefresher` in the package — you normally do not call these directly from app code; ensure shops use `apiHelper()` (or equivalent documented entry points) so refresh runs when needed.
+- Refresh failures throw `Osiset\ShopifyApp\Exceptions\OAuthTokenRefreshException` — handle or log in **your** exception reporting so ops can re-authenticate affected shops.
+
+## Operational notes
+
+- Keep **`APP_KEY` stable** in each environment; encrypted column values depend on it.
+- Plan for **re-install or re-auth** when refresh tokens are revoked or invalid per Shopify.
+
+## Do / Don’t
+
+- **Do** enable `expiring_offline_tokens` and run migrations **before** assuming refresh metadata exists for legacy rows.
+- **Don’t** store plaintext tokens in custom columns outside what the package supports without a documented security review.

--- a/resources/boost/skills/shopify-app-webhooks/SKILL.md
+++ b/resources/boost/skills/shopify-app-webhooks/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: shopify-app-webhooks
+description: Registering and handling Shopify webhooks in a Laravel app using kyon147/laravel-shopify.
+---
+
+## When to use
+
+You are in a **host Laravel application** with `kyon147/laravel-shopify` and you are configuring **webhooks**: topics and URLs, uninstall / compliance / GDPR flows, queue workers, or custom handlers alongside the package’s default webhook endpoint.
+
+## Declaring webhooks (your published config)
+
+In **published** `config/shopify-app.php`, the `webhooks` array defines GraphQL-style `topic` values and `address` URLs Shopify should call. You can map entries to a custom job class using a `class` key (see commented examples in the package’s default `src/resources/config/shopify-app.php`).
+
+Ensure `address` values are reachable from the internet (ngrok / cloud tunnel in local dev) and match your app’s routes.
+
+## Verification and dispatch (package behavior)
+
+- Incoming webhooks should hit routes protected with `auth.webhook` middleware (`Osiset\ShopifyApp\Http\Middleware\AuthWebhook`) so HMAC verification runs before your logic executes.
+- Package `WebhookController` + `Traits/WebhookController` show how payloads are turned into jobs — use as **read-only reference** when adding **your** job classes mapped in config.
+
+## Queues and jobs (your app)
+
+- Configure `queue.php` and workers so webhook jobs actually run in production.
+- Package config includes `job_queues` / `job_connections` entries (e.g. `webhooks`) — set `WEBHOOKS_JOB_QUEUE` / `WEBHOOKS_JOB_CONNECTION` in `.env` if you isolate webhook traffic.
+- Listen for package events in **your** `config/shopify-app.php` `listen` array (e.g. `AppUninstalledEvent`) and dispatch **your** listeners or jobs for cleanup.
+
+## Do / Don’t
+
+- **Do** register mandatory compliance webhooks required by Shopify for your app type.
+- **Don’t** expose webhook URLs without HMAC verification or skip `auth.webhook` on routes that accept Shopify payloads.


### PR DESCRIPTION
As AI assisted development becomes more popular, and with the launch of [Laravel Boost](https://laravel.com/ai/boost), this PR adds relevant guidelines AI agents to look at when working on apps that consume this package. 

I've also updated the contributing guidelines because the agent guidelines should be kept up to date. 

Once this is merged, providing you've got Laravel Boost installed, you can run `php artisan boost:install` and `kyon147/laravel-shopify` will show up as a set of installable guidelines. 

More and more packages are adding Boost guidelines, here's some examples from other packages:

- [PrismPHP](https://github.com/prism-php/prism/tree/main/resources/boost)
- [Laravel Debugbar](https://github.com/fruitcake/laravel-debugbar/tree/master/resources/boost/skills/debug-using-debugbar)