### PR TITLE
Migrate package enums to native PHP backed enums

### DIFF
--- a/src/Actions/ActivatePlan.php
+++ b/src/Actions/ActivatePlan.php
@@ -40,7 +40,7 @@ class ActivatePlan
     {
         $shop = $this->shopQuery->getById($shopId);
         $plan = $this->planQuery->getById($planId);
-        $chargeType = ChargeType::fromNative($plan->getType()->toNative());
+        $chargeType = ChargeType::fromNative($plan->getType()->value);
 
         // Activate the plan on Shopify
         $response = $shop->apiHelper()->activateCharge($chargeType, $chargeRef);
@@ -54,10 +54,10 @@ class ActivatePlan
         $transfer->planId = $planId;
         $transfer->chargeReference = $chargeRef;
         $transfer->chargeType = $chargeType;
-        $transfer->chargeStatus = ChargeStatus::fromNative(strtoupper($response['status']));
+        $transfer->chargeStatus = ChargeStatus::fromShopifyApiStatus($response['status']);
         $transfer->planDetails = $this->chargeHelper->details($plan, $shop, $host);
 
-        if ($plan->isType(PlanType::RECURRING())) {
+        if ($plan->isType(PlanType::RECURRING)) {
             $transfer->activatedOn = new Carbon($response['activated_on']);
             $transfer->billingOn = new Carbon($response['billing_on']);
             $transfer->trialEndsOn = new Carbon($response['trial_ends_on']);

--- a/src/Actions/ActivateUsageCharge.php
+++ b/src/Actions/ActivateUsageCharge.php
@@ -33,7 +33,7 @@ class ActivateUsageCharge
         // Ensure we have a recurring charge
         $currentCharge = $this->chargeHelper->chargeForPlan($shop->plan->getId(), $shop);
 
-        if (! $currentCharge->isType(ChargeType::RECURRING())) {
+        if (! $currentCharge->isType(ChargeType::RECURRING)) {
             throw new ChargeNotRecurringException('Can only create usage charges for recurring charge.');
         }
 

--- a/src/Actions/CancelCharge.php
+++ b/src/Actions/CancelCharge.php
@@ -25,7 +25,7 @@ class CancelCharge
         $helper = $this->chargeHelper->useCharge($chargeRef);
         $charge = $helper->getCharge();
 
-        if (! $charge->isType(ChargeType::CHARGE()) && ! $charge->isType(ChargeType::RECURRING())) {
+        if (! $charge->isType(ChargeType::CHARGE) && ! $charge->isType(ChargeType::RECURRING)) {
             // Not a recurring or one-time charge, someone trying to cancel a usage charge?
             throw new ChargeNotRecurringOrOnetimeException(
                 'Cancel may only be called for single and recurring charges.'

--- a/src/Actions/GetPlanUrl.php
+++ b/src/Actions/GetPlanUrl.php
@@ -27,7 +27,7 @@ class GetPlanUrl
         $shop = $this->shopQuery->getById($shopId);
         $plan = $planId->isNull() ? $this->planQuery->getDefault() : $this->planQuery->getById($planId);
 
-        if ($plan->getInterval()->toNative() === ChargeInterval::ANNUAL()->toNative()) {
+        if ($plan->getInterval()->value === ChargeInterval::ANNUAL->value) {
             $api = $shop->apiHelper()
                 ->createChargeGraphQL($this->chargeHelper->details($plan, $shop, $host));
 
@@ -35,7 +35,7 @@ class GetPlanUrl
         } else {
             $api = $shop->apiHelper()
                 ->createCharge(
-                    ChargeType::fromNative($plan->getType()->toNative()),
+                    ChargeType::fromNative($plan->getType()->value),
                     $this->chargeHelper->details($plan, $shop, $host)
                 );
 

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -8,11 +8,10 @@ use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
 use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
 use Osiset\ShopifyApp\Objects\Enums\AuthMode;
-use Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel as ThemeSupportLevelEnum;
 use Osiset\ShopifyApp\Objects\Values\AccessToken;
 use Osiset\ShopifyApp\Objects\Values\NullAccessToken;
 use Osiset\ShopifyApp\Objects\Values\ShopDomain;
-use Osiset\ShopifyApp\Objects\Values\ThemeSupportLevel;
+use Osiset\ShopifyApp\Objects\Values\ThemeSupportLevel as ThemeSupportLevelValue;
 use Osiset\ShopifyApp\Util;
 
 class InstallShop
@@ -35,8 +34,8 @@ class InstallShop
 
         $apiHelper = $shop->apiHelper();
         $grantMode = $shop->hasOfflineAccess()
-            ? AuthMode::fromNative(Util::getShopifyConfig('api_grant_mode', $shop))
-            : AuthMode::OFFLINE();
+            ? AuthMode::fromNative(strtoupper((string) Util::getShopifyConfig('api_grant_mode', $shop)))
+            : AuthMode::OFFLINE;
 
         if (empty($code) && empty($idToken)) {
             return [
@@ -59,17 +58,16 @@ class InstallShop
 
             try {
                 $themeSupportLevel = call_user_func($this->verifyThemeSupport, $shop->getId());
-                $this->shopCommand->setThemeSupportLevel($shop->getId(), ThemeSupportLevel::fromNative($themeSupportLevel));
+                $this->shopCommand->setThemeSupportLevel($shop->getId(), ThemeSupportLevelValue::fromNative($themeSupportLevel->value));
             } catch (Exception $e) {
-                $themeSupportLevel = ThemeSupportLevelEnum::NONE;
+                $themeSupportLevel = null;
             }
-
 
             return [
                 'completed' => true,
                 'url' => null,
                 'shop_id' => $shop->getId(),
-                'theme_support_level' => $themeSupportLevel,
+                'theme_support_level' => $themeSupportLevel?->value,
             ];
         } catch (Exception $e) {
             return [
@@ -93,7 +91,7 @@ class InstallShop
     protected function persistShopifyOAuthTokens(IShopModel $shop, $data, AuthMode $grantMode): void
     {
         $expiringEnabled = Util::getShopifyConfig('expiring_offline_tokens', $shop);
-        $isOfflineGrant = $grantMode->isSame(AuthMode::OFFLINE());
+        $isOfflineGrant = $grantMode === AuthMode::OFFLINE;
 
         if ($expiringEnabled && $isOfflineGrant && isset($data['refresh_token'])) {
             $this->shopCommand->setAccessToken(

--- a/src/Actions/VerifyThemeSupport.php
+++ b/src/Actions/VerifyThemeSupport.php
@@ -15,7 +15,7 @@ class VerifyThemeSupport
     ) {
     }
 
-    public function __invoke(ShopId $shopId): int
+    public function __invoke(ShopId $shopId): ThemeSupportLevel
     {
         $this->themeHelper->extractStoreMainTheme($shopId);
 

--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -352,11 +352,11 @@ class VerifyShopify
         // All possible methods
         $options = [
             // GET/POST
-            DataSource::INPUT()->toNative() => $request->input('hmac'),
+            DataSource::INPUT->value => $request->input('hmac'),
             // Headers
-            DataSource::HEADER()->toNative() => $request->header('X-Shop-Signature'),
+            DataSource::HEADER->value => $request->header('X-Shop-Signature'),
             // Headers: Referer
-            DataSource::REFERER()->toNative() => function () use ($request): ?string {
+            DataSource::REFERER->value => function () use ($request): ?string {
                 $url = parse_url($request->header('referer', ''), PHP_URL_QUERY);
                 parse_str($url ?? '', $refererQueryParams);
                 if (! $refererQueryParams || ! isset($refererQueryParams['hmac'])) {
@@ -405,7 +405,7 @@ class VerifyShopify
         // All possible methods
         $options = [
             // GET/POST
-            DataSource::INPUT()->toNative() => function () use ($request): array {
+            DataSource::INPUT->value => function () use ($request): array {
                 // Verify
                 $verify = [];
                 foreach ($request->query() as $key => $value) {
@@ -415,7 +415,7 @@ class VerifyShopify
                 return $verify;
             },
             // Headers
-            DataSource::HEADER()->toNative() => function () use ($request): array {
+            DataSource::HEADER->value => function () use ($request): array {
                 // Always present
                 $shop = $request->header('X-Shop-Domain');
                 $signature = $request->header('X-Shop-Signature');
@@ -443,7 +443,7 @@ class VerifyShopify
                 return $verify;
             },
             // Headers: Referer
-            DataSource::REFERER()->toNative() => function () use ($request): array {
+            DataSource::REFERER->value => function () use ($request): array {
                 $url = parse_url($request->header('referer'), PHP_URL_QUERY);
                 parse_str($url, $refererQueryParams);
 

--- a/src/Objects/Enums/ApiMethod.php
+++ b/src/Objects/Enums/ApiMethod.php
@@ -2,46 +2,23 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
  * API call method types.
  *
- * @method static ApiMethod GET()
- * @method static ApiMethod POST()
- * @method static ApiMethod PUT()
- * @method static ApiMethod DELETE()
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
  */
-final class ApiMethod implements ValueObject
+enum ApiMethod: string
 {
-    use EnumTrait;
+    case GET = 'GET';
+    case POST = 'POST';
+    case PUT = 'PUT';
+    case DELETE = 'DELETE';
 
     /**
-     * HTTP method: GET.
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const GET = 0;
-
-    /**
-     * HTTP method: POST.
-     *
-     * @var int
-     */
-    public const POST = 1;
-
-    /**
-     * HTTP method: PUT.
-     *
-     * @var int
-     */
-    public const PUT = 2;
-
-    /**
-     * HTTP method: DELETE.
-     *
-     * @var int
-     */
-    public const DELETE = 3;
+    public static function fromNative(string $name): self
+    {
+        return self::from(strtoupper($name));
+    }
 }

--- a/src/Objects/Enums/AuthMode.php
+++ b/src/Objects/Enums/AuthMode.php
@@ -2,30 +2,21 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
  * API auth modes.
  *
- * @method static AuthMode OFFLINE()
- * @method static AuthMode PERUSER()
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
  */
-final class AuthMode implements ValueObject
+enum AuthMode: string
 {
-    use EnumTrait;
+    case OFFLINE = 'OFFLINE';
+    case PERUSER = 'PERUSER';
 
     /**
-     * Offline auth mode.
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const OFFLINE = 0;
-
-    /**
-     * Per-user auth mode.
-     *
-     * @var int
-     */
-    public const PERUSER = 1;
+    public static function fromNative(string $name): self
+    {
+        return self::from(strtoupper($name));
+    }
 }

--- a/src/Objects/Enums/ChargeInterval.php
+++ b/src/Objects/Enums/ChargeInterval.php
@@ -2,30 +2,21 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
  * Charge interval with annual support.
  *
- * @method static ChargeInterval EVERY_30_DAYS()
- * @method static ChargeInterval ANNUAL()
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
  */
-class ChargeInterval implements ValueObject
+enum ChargeInterval: string
 {
-    use EnumTrait;
+    case EVERY_30_DAYS = 'EVERY_30_DAYS';
+    case ANNUAL = 'ANNUAL';
 
     /**
-     * Interval: Monthly.
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const EVERY_30_DAYS = 1;
-
-    /**
-     * Interval: Annual.
-     *
-     * @var int
-     */
-    public const ANNUAL = 2;
+    public static function fromNative(string $name): self
+    {
+        return self::from(strtoupper($name));
+    }
 }

--- a/src/Objects/Enums/ChargeStatus.php
+++ b/src/Objects/Enums/ChargeStatus.php
@@ -2,54 +2,29 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
  * API charge status.
  *
- * @method static ChargeStatus ACTIVE()
- * @method static ChargeStatus ACCEPTED()
- * @method static ChargeStatus DECLINED()
- * @method static ChargeStatus CANCELLED()
- * @method static ChargeStatus PENDING()
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
  */
-final class ChargeStatus implements ValueObject
+enum ChargeStatus: string
 {
-    use EnumTrait;
+    case ACTIVE = 'ACTIVE';
+    case ACCEPTED = 'ACCEPTED';
+    case DECLINED = 'DECLINED';
+    case CANCELLED = 'CANCELLED';
+    case PENDING = 'PENDING';
 
     /**
-     * Status: Active.
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const ACTIVE = 0;
+    public static function fromNative(string $name): self
+    {
+        return self::from(strtoupper($name));
+    }
 
-    /**
-     * Status: Accepted.
-     *
-     * @var int
-     */
-    public const ACCEPTED = 1;
-
-    /**
-     * Status: Declines.
-     *
-     * @var int
-     */
-    public const DECLINED = 2;
-
-    /**
-     * Status: Cancelled.
-     *
-     * @var int
-     */
-    public const CANCELLED = 3;
-
-    /**
-     * Status: Pending.
-     *
-     * @var int
-     */
-    public const PENDING = 4;
+    public static function fromShopifyApiStatus(string $status): self
+    {
+        return self::from(strtoupper($status));
+    }
 }

--- a/src/Objects/Enums/ChargeType.php
+++ b/src/Objects/Enums/ChargeType.php
@@ -2,54 +2,29 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
  * API types for charges.
  *
- * @method static ChargeType RECURRING()
- * @method static ChargeType CHARGE()
- * @method static ChargeType ONETIME()
- * @method static ChargeType USAGE()
- * @method static ChargeType CREDIT()
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
+ * {@see self::ONETIME} is not a separate case: use {@see self::CHARGE} (same int as legacy); accept "ONETIME" in {@see fromNative()}.
  */
-final class ChargeType implements ValueObject
+enum ChargeType: string
 {
-    use EnumTrait;
+    case RECURRING = 'RECURRING';
+    case CHARGE = 'CHARGE';
+    case USAGE = 'USAGE';
+    case CREDIT = 'CREDIT';
 
     /**
-     * Charge: Recurring.
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const RECURRING = 1;
+    public static function fromNative(string $name): self
+    {
+        $upper = strtoupper($name);
 
-    /**
-     * Charge: One-time.
-     *
-     * @var int
-     */
-    public const CHARGE = 2;
-
-    /**
-     * Charge: Alias for onetime.
-     *
-     * @var int
-     */
-    public const ONETIME = 2;
-
-    /**
-     * Charge: Usage.
-     *
-     * @var int
-     */
-    public const USAGE = 3;
-
-    /**
-     * Charge: Credit.
-     *
-     * @var int
-     */
-    public const CREDIT = 4;
+        return match ($upper) {
+            'ONETIME' => self::CHARGE,
+            default => self::from($upper),
+        };
+    }
 }

--- a/src/Objects/Enums/DataSource.php
+++ b/src/Objects/Enums/DataSource.php
@@ -2,38 +2,22 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
  * Source of data for Shopify requests.
  *
- * @method static DataSource INPUT()
- * @method static DataSource HEADER()
- * @method static DataSource REFERER()
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
  */
-final class DataSource implements ValueObject
+enum DataSource: string
 {
-    use EnumTrait;
+    case INPUT = 'INPUT';
+    case HEADER = 'HEADER';
+    case REFERER = 'REFERER';
 
     /**
-     * Input (GET/POST).
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const INPUT = 0;
-
-    /**
-     * Header (X-Shopify).
-     *
-     * @var int
-     */
-    public const HEADER = 1;
-
-    /**
-     * Referer (Header).
-     *
-     * @var int
-     */
-    public const REFERER = 2;
+    public static function fromNative(string $name): self
+    {
+        return self::from(strtoupper($name));
+    }
 }

--- a/src/Objects/Enums/FrontendType.php
+++ b/src/Objects/Enums/FrontendType.php
@@ -2,20 +2,21 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
-class FrontendType implements ValueObject
+/**
+ * Frontend type (MPA vs SPA).
+ *
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
+ */
+enum FrontendType: string
 {
-    use EnumTrait;
+    case MPA = 'MPA';
+    case SPA = 'SPA';
 
     /**
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const MPA = 0;
-
-    /**
-     * @var int
-     */
-    public const SPA = 1;
+    public static function fromNative(string $name): self
+    {
+        return self::from(strtoupper($name));
+    }
 }

--- a/src/Objects/Enums/PlanInterval.php
+++ b/src/Objects/Enums/PlanInterval.php
@@ -2,30 +2,21 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
  * Plan interval with annual support.
  *
- * @method static PlanInterval EVERY_30_DAYS()
- * @method static PlanInterval ANNUAL()
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
  */
-class PlanInterval implements ValueObject
+enum PlanInterval: string
 {
-    use EnumTrait;
+    case EVERY_30_DAYS = 'EVERY_30_DAYS';
+    case ANNUAL = 'ANNUAL';
 
     /**
-     * Interval: Monthly.
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const EVERY_30_DAYS = 1;
-
-    /**
-     * Interval: Annual.
-     *
-     * @var int
-     */
-    public const ANNUAL = 2;
+    public static function fromNative(string $name): self
+    {
+        return self::from(strtoupper($name));
+    }
 }

--- a/src/Objects/Enums/PlanType.php
+++ b/src/Objects/Enums/PlanType.php
@@ -2,30 +2,21 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
  * API types for plans.
  *
- * @method static PlanType RECURRING()
- * @method static PlanType ONETIME()
+ * Backing values match legacy Funeralzone {@see EnumTrait} {@see toNative()} (constant name strings).
  */
-final class PlanType implements ValueObject
+enum PlanType: string
 {
-    use EnumTrait;
+    case RECURRING = 'RECURRING';
+    case ONETIME = 'ONETIME';
 
     /**
-     * Plan: Recurring.
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const RECURRING = 0;
-
-    /**
-     * Plan: One-time.
-     *
-     * @var int
-     */
-    public const ONETIME = 1;
+    public static function fromNative(string $name): self
+    {
+        return self::from(strtoupper($name));
+    }
 }

--- a/src/Objects/Enums/SessionTokenSource.php
+++ b/src/Objects/Enums/SessionTokenSource.php
@@ -2,30 +2,21 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
- * API call method types.
+ * Which Shopify session-token shape is in use.
  *
- * @method static SessionTokenSource APP()
- * @method static SessionTokenSource CHECKOUT_EXTENSION()
+ * Integer backing matches legacy public int constants on the previous class.
  */
-final class SessionTokenSource implements ValueObject
+enum SessionTokenSource: int
 {
-    use EnumTrait;
+    case APP = 0;
+    case CHECKOUT_EXTENSION = 1;
 
     /**
-     * Token form Shopify App
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const APP = 0;
-
-    /**
-     * Token from UI extension
-     *
-     * @var int
-     */
-    public const CHECKOUT_EXTENSION = 1;
+    public static function fromNative(int $value): self
+    {
+        return self::from($value);
+    }
 }

--- a/src/Objects/Enums/ThemeSupportLevel.php
+++ b/src/Objects/Enums/ThemeSupportLevel.php
@@ -2,41 +2,23 @@
 
 namespace Osiset\ShopifyApp\Objects\Enums;
 
-use Funeralzone\ValueObjects\Enums\EnumTrait;
-use Funeralzone\ValueObjects\ValueObject;
-
 /**
- * Online Store 2.0 theme support
+ * Online Store 2.0 theme support level.
+ *
+ * Integer backing matches legacy public int constants on the previous class.
+ * There is no enum case for legacy {@see NONE} (null); represent “unknown / skipped” with null in application code.
  */
-class ThemeSupportLevel implements ValueObject
+enum ThemeSupportLevel: int
 {
-    use EnumTrait;
+    case FULL = 0;
+    case PARTIAL = 1;
+    case UNSUPPORTED = 2;
 
     /**
-     * Support level: fully.
-     *
-     * @var int
+     * @deprecated Use {@see self::tryFrom()} or enum cases; kept for backward compatibility with ValueObject API.
      */
-    public const FULL = 0;
-
-    /**
-     * Support level: partial.
-     *
-     * @var int
-     */
-    public const PARTIAL = 1;
-
-    /**
-     * Support level: unsupported.
-     *
-     * @var int
-     */
-    public const UNSUPPORTED = 2;
-
-    /**
-     * Support level: None.
-     *
-     * @var null
-     */
-    public const NONE = null;
+    public static function fromNative(int $value): self
+    {
+        return self::from($value);
+    }
 }

--- a/src/Objects/Transfers/UsageCharge.php
+++ b/src/Objects/Transfers/UsageCharge.php
@@ -69,7 +69,7 @@ final class UsageCharge extends AbstractTransfer
      */
     public function __construct()
     {
-        $this->chargeType = ChargeType::USAGE();
-        $this->chargeStatus = ChargeStatus::ACCEPTED();
+        $this->chargeType = ChargeType::USAGE;
+        $this->chargeStatus = ChargeStatus::ACCEPTED;
     }
 }

--- a/src/Objects/Values/SessionToken.php
+++ b/src/Objects/Values/SessionToken.php
@@ -133,10 +133,8 @@ final class SessionToken implements SessionTokenValue
 
     /**
      * Shopify has multiple session tokens, slightly differing in format.
-     *
-     * @var string
      */
-    protected $tokenSource = SessionTokenSource::APP;
+    protected SessionTokenSource $tokenSource = SessionTokenSource::APP;
 
     /**
      * Constructor.
@@ -396,9 +394,9 @@ final class SessionToken implements SessionTokenValue
         ])->false(self::EXCEPTION_EXPIRED);
     }
 
-    protected function determineTokenSource(array $body): int
+    protected function determineTokenSource(array $body): SessionTokenSource
     {
-        if (!isset($body['sid'])) {
+        if (! isset($body['sid'])) {
             return SessionTokenSource::CHECKOUT_EXTENSION;
         }
 

--- a/src/Objects/Values/ShopDomain.php
+++ b/src/Objects/Values/ShopDomain.php
@@ -53,13 +53,13 @@ final class ShopDomain implements ShopDomainValue
         // All possible methods
         $options = [
             // GET/POST
-            DataSource::INPUT()->toNative() => $request->input('shop', $request->input('shopDomain')),
+            DataSource::INPUT->value => $request->input('shop', $request->input('shopDomain')),
 
             // Headers
-            DataSource::HEADER()->toNative() => $request->header('X-Shop-Domain'),
+            DataSource::HEADER->value => $request->header('X-Shop-Domain'),
 
             // Headers: Referer
-            DataSource::REFERER()->toNative() => function () use ($request): ?string {
+            DataSource::REFERER->value => function () use ($request): ?string {
                 $url = parse_url($request->header('referer', ''), PHP_URL_QUERY);
                 if (! $url) {
                     return null;

--- a/src/Services/ApiHelper.php
+++ b/src/Services/ApiHelper.php
@@ -127,7 +127,7 @@ class ApiHelper implements IApiHelper
     public function buildAuthUrl(AuthMode $mode, string $scopes): string
     {
         // Fix for peruser => per-user
-        $mode = $mode->isSame(AuthMode::PERUSER()) ? 'PER-USER' : $mode->toNative();
+        $mode = $mode === AuthMode::PERUSER ? 'PER-USER' : $mode->value;
 
         return $this->api->getAuthUrl(
             $scopes,
@@ -174,10 +174,10 @@ class ApiHelper implements IApiHelper
      */
     public function getAccessData(string $code, ?AuthMode $grantMode = null): ResponseAccess
     {
-        $grantMode = $grantMode ?? AuthMode::OFFLINE();
+        $grantMode = $grantMode ?? AuthMode::OFFLINE;
         $shop = $this->getShopDomain($this->api->getSession())->toNative();
         $useExpiringOffline = Util::getShopifyConfig('expiring_offline_tokens', $shop)
-            && $grantMode->isSame(AuthMode::OFFLINE());
+            && $grantMode === AuthMode::OFFLINE;
 
         if ($useExpiringOffline) {
             return $this->oauthAccessTokenPost([
@@ -249,7 +249,7 @@ class ApiHelper implements IApiHelper
 
         // Fire the request
         $response = $this->doRequest(
-            ApiMethod::GET(),
+            ApiMethod::GET,
             '/admin/script_tags.json',
             $reqParams
         );
@@ -265,7 +265,7 @@ class ApiHelper implements IApiHelper
     {
         // Fire the request
         $response = $this->doRequest(
-            ApiMethod::POST(),
+            ApiMethod::POST,
             '/admin/script_tags.json',
             ['script_tag' => $payload]
         );
@@ -281,7 +281,7 @@ class ApiHelper implements IApiHelper
     {
         // Fire the request
         $response = $this->doRequest(
-            ApiMethod::DELETE(),
+            ApiMethod::DELETE,
             "/admin/script_tags/{$scriptTagId}.json"
         );
 
@@ -299,7 +299,7 @@ class ApiHelper implements IApiHelper
 
         // Fire the request
         $response = $this->doRequest(
-            ApiMethod::GET(),
+            ApiMethod::GET,
             "/admin/{$typeString}s/{$chargeRef->toNative()}.json"
         );
 
@@ -317,7 +317,7 @@ class ApiHelper implements IApiHelper
 
         // Fire the request
         $response = $this->doRequest(
-            ApiMethod::POST(),
+            ApiMethod::POST,
             "/admin/{$typeString}s/{$chargeRef->toNative()}/activate.json"
         );
 
@@ -335,7 +335,7 @@ class ApiHelper implements IApiHelper
 
         // Fire the request
         $response = $this->doRequest(
-            ApiMethod::POST(),
+            ApiMethod::POST,
             "/admin/{$typeString}s.json",
             [$typeString => $payload->toArray()]
         );
@@ -515,7 +515,7 @@ class ApiHelper implements IApiHelper
     {
         // Fire the request
         $response = $this->doRequest(
-            ApiMethod::POST(),
+            ApiMethod::POST,
             "/admin/recurring_application_charges/{$payload->chargeReference->toNative()}/usage_charges.json",
             [
                 'usage_charge' => [
@@ -539,15 +539,15 @@ class ApiHelper implements IApiHelper
     protected function chargeApiPath(ChargeType $chargeType): string
     {
         // Convert to API path
-        if ($chargeType->isSame(ChargeType::RECURRING())) {
+        if ($chargeType === ChargeType::RECURRING) {
             $format = '%s_application_charge';
-        } elseif ($chargeType->isSame(ChargeType::CHARGE())) {
+        } elseif ($chargeType === ChargeType::CHARGE) {
             $format = 'application_charge';
         } else {
             $format = 'application_%s';
         }
 
-        return sprintf($format, strtolower($chargeType->toNative()));
+        return sprintf($format, strtolower($chargeType->value));
     }
 
     /**
@@ -563,7 +563,7 @@ class ApiHelper implements IApiHelper
      */
     protected function doRequest(ApiMethod $method, string $path, ?array $payload = null)
     {
-        $response = $this->api->rest($method->toNative(), $path, $payload);
+        $response = $this->api->rest($method->value, $path, $payload);
         if ($response['errors'] === true) {
             // Request error somewhere, throw the exception
             throw new ApiException(
@@ -616,15 +616,15 @@ class ApiHelper implements IApiHelper
 
         $options = [
             // Input
-            DataSource::INPUT()->toNative() => function (): ?string {
+            DataSource::INPUT->value => function (): ?string {
                 return Arr::get(Request::all(), 'shop');
             },
             // Headers
-            DataSource::HEADER()->toNative() => function (): ?string {
+            DataSource::HEADER->value => function (): ?string {
                 return Request::header('X-Shop-Domain');
             },
             // Headers: Referer
-            DataSource::REFERER()->toNative() => function (): ?string {
+            DataSource::REFERER->value => function (): ?string {
                 $url = parse_url(Request::server('HTTP_REFERER', ''), PHP_URL_QUERY);
                 parse_str($url ?? '', $refererQueryParams);
 

--- a/src/Services/ChargeHelper.php
+++ b/src/Services/ChargeHelper.php
@@ -202,7 +202,7 @@ class ChargeHelper
         $transfer = new PlanDetailsTransfer();
         $transfer->name = $plan->name;
         $transfer->price = $plan->price;
-        $transfer->interval = $plan->getInterval()->toNative();
+        $transfer->interval = $plan->getInterval()->value;
         $transfer->test = $plan->isTest();
         $transfer->trialDays = $this->determineTrialDaysRemaining($plan, $shop);
         $transfer->cappedAmount = $isCapped ? $plan->capped_amount : null;
@@ -261,7 +261,7 @@ class ChargeHelper
         return $shop
             ->charges()
             ->withTrashed()
-            ->whereIn('type', [ChargeType::RECURRING()->toNative(), ChargeType::CHARGE()->toNative()])
+            ->whereIn('type', [ChargeType::RECURRING->value, ChargeType::CHARGE->value])
             ->where('plan_id', $planId->toNative())
             ->orderBy('created_at', 'desc')
             ->first();

--- a/src/Storage/Commands/Charge.php
+++ b/src/Storage/Commands/Charge.php
@@ -57,8 +57,8 @@ class Charge implements ChargeCommand
         $charge->plan_id = $chargeObj->planId->toNative();
         $charge->$shopTableId = $chargeObj->shopId->toNative();
         $charge->charge_id = $chargeObj->chargeReference->toNative();
-        $charge->type = $chargeObj->chargeType->toNative();
-        $charge->status = $chargeObj->chargeStatus->toNative();
+        $charge->type = $chargeObj->chargeType->value;
+        $charge->status = $chargeObj->chargeStatus->value;
         $charge->name = $chargeObj->planDetails->name;
         $charge->price = $chargeObj->planDetails->price;
         $charge->interval = $chargeObj->planDetails->interval;
@@ -97,8 +97,8 @@ class Charge implements ChargeCommand
         $charge = new $chargeClass();
         $charge->$shopTableId = $chargeObj->shopId->toNative();
         $charge->charge_id = $chargeObj->chargeReference->toNative();
-        $charge->type = $chargeObj->chargeType->toNative();
-        $charge->status = $chargeObj->chargeStatus->toNative();
+        $charge->type = $chargeObj->chargeType->value;
+        $charge->status = $chargeObj->chargeStatus->value;
         $charge->price = $chargeObj->details->price;
         $charge->description = $chargeObj->details->description;
         $charge->reference_charge = $chargeObj->details->chargeReference->toNative();
@@ -118,7 +118,7 @@ class Charge implements ChargeCommand
         ?Carbon $trialEndsOn = null
     ): bool {
         $charge = $this->query->getByReference($chargeRef);
-        $charge->status = ChargeStatus::CANCELLED()->toNative();
+        $charge->status = ChargeStatus::CANCELLED->value;
         $charge->cancelled_on = $expiresOn === null ? Carbon::today()->format('Y-m-d') : $expiresOn->format('Y-m-d');
         $charge->expires_on = $trialEndsOn === null ? Carbon::today()->format('Y-m-d') : $trialEndsOn->format('Y-m-d');
 

--- a/src/Storage/Models/Charge.php
+++ b/src/Storage/Models/Charge.php
@@ -36,6 +36,8 @@ class Charge extends Model
      * @var array
      */
     protected $casts = [
+        'type' => ChargeType::class,
+        'status' => ChargeStatus::class,
         'test' => 'bool',
         'capped_amount' => 'float',
         'price' => 'float',
@@ -119,11 +121,11 @@ class Charge extends Model
     public function getTypeApiString($plural = false): string
     {
         $types = [
-            ChargeType::CREDIT()->toNative() => 'application_credit',
-            ChargeType::CHARGE()->toNative() => 'application_charge',
-            ChargeType::RECURRING()->toNative() => 'recurring_application_charge',
+            ChargeType::CREDIT->value => 'application_credit',
+            ChargeType::CHARGE->value => 'application_charge',
+            ChargeType::RECURRING->value => 'recurring_application_charge',
         ];
-        $type = $types[$this->getType()->toNative()];
+        $type = $types[$this->getType()->value];
 
         return $plural ? "{$type}s" : $type;
     }
@@ -145,7 +147,7 @@ class Charge extends Model
      */
     public function getType(): ChargeType
     {
-        return ChargeType::fromNative($this->type);
+        return $this->type;
     }
 
     /**
@@ -157,7 +159,7 @@ class Charge extends Model
      */
     public function isType(ChargeType $type): bool
     {
-        return $this->getType()->isSame($type);
+        return $this->getType() === $type;
     }
 
     /**
@@ -177,7 +179,7 @@ class Charge extends Model
      */
     public function getStatus(): ChargeStatus
     {
-        return ChargeStatus::fromNative($this->status);
+        return $this->status ?? ChargeStatus::PENDING;
     }
 
     /**
@@ -189,7 +191,7 @@ class Charge extends Model
      */
     public function isStatus(ChargeStatus $status): bool
     {
-        return $this->getStatus()->isSame($status);
+        return $this->getStatus() === $status;
     }
 
     /**
@@ -199,7 +201,7 @@ class Charge extends Model
      */
     public function isActive(): bool
     {
-        return $this->isStatus(ChargeStatus::ACTIVE());
+        return $this->isStatus(ChargeStatus::ACTIVE);
     }
 
     /**
@@ -209,7 +211,7 @@ class Charge extends Model
      */
     public function isAccepted(): bool
     {
-        return $this->isStatus(ChargeStatus::ACCEPTED());
+        return $this->isStatus(ChargeStatus::ACCEPTED);
     }
 
     /**
@@ -219,7 +221,7 @@ class Charge extends Model
      */
     public function isDeclined(): bool
     {
-        return $this->isStatus(ChargeStatus::DECLINED());
+        return $this->isStatus(ChargeStatus::DECLINED);
     }
 
     /**
@@ -229,7 +231,7 @@ class Charge extends Model
      */
     public function isCancelled(): bool
     {
-        return $this->cancelled_on !== null || $this->isStatus(ChargeStatus::CANCELLED());
+        return $this->cancelled_on !== null || $this->isStatus(ChargeStatus::CANCELLED);
     }
 
     /**

--- a/src/Storage/Models/Plan.php
+++ b/src/Storage/Models/Plan.php
@@ -20,6 +20,8 @@ class Plan extends Model
      * @var array
      */
     protected $casts = [
+        'type' => PlanType::class,
+        'interval' => PlanInterval::class,
         'test' => 'bool',
         'on_install' => 'bool',
         'capped_amount' => 'float',
@@ -63,7 +65,7 @@ class Plan extends Model
      */
     public function getType(): PlanType
     {
-        return PlanType::fromNative($this->type);
+        return $this->type;
     }
 
     /**
@@ -73,7 +75,7 @@ class Plan extends Model
      */
     public function getInterval(): PlanInterval
     {
-        return $this->interval ? PlanInterval::fromNative($this->interval) : PlanInterval::EVERY_30_DAYS();
+        return $this->interval ?? PlanInterval::EVERY_30_DAYS;
     }
 
     /**
@@ -85,7 +87,7 @@ class Plan extends Model
      */
     public function isType(PlanType $type): bool
     {
-        return $this->getType()->isSame($type);
+        return $this->getType() === $type;
     }
 
     /**
@@ -98,10 +100,10 @@ class Plan extends Model
     public function getTypeApiString($plural = false): string
     {
         $types = [
-            PlanType::ONETIME()->toNative() => 'application_charge',
-            PlanType::RECURRING()->toNative() => 'recurring_application_charge',
+            PlanType::ONETIME->value => 'application_charge',
+            PlanType::RECURRING->value => 'recurring_application_charge',
         ];
-        $type = $types[$this->getType()->toNative()];
+        $type = $types[$this->getType()->value];
 
         return $plural ? "{$type}s" : $type;
     }

--- a/src/Util.php
+++ b/src/Util.php
@@ -245,7 +245,7 @@ class Util
             self::getShopifyConfig('frontend_type') ?? 'MPA'
         );
 
-        return !$frontendType->isSame(FrontendType::fromNative('SPA'));
+        return $frontendType !== FrontendType::SPA;
     }
 
     public static function hasAppLegacySupport(string $feature): bool

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -587,7 +587,7 @@ return [
          * Available levels: FULL, PARTIAL, UNSUPPORTED.
          */
         'unacceptable_levels' => [
-            Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel::UNSUPPORTED,
+            Osiset\ShopifyApp\Objects\Enums\ThemeSupportLevel::UNSUPPORTED->value,
         ],
     ],
 

--- a/src/resources/database/factories/ChargeFactory.php
+++ b/src/resources/database/factories/ChargeFactory.php
@@ -14,7 +14,7 @@ $factory->define($chargeModel, function (Faker $faker) {
         'charge_id' => $faker->randomNumber(8),
         'name' => $faker->word(),
         'price' => $faker->randomFloat(),
-        'status' => ChargeStatus::ACCEPTED()->toNative(),
+        'status' => ChargeStatus::ACCEPTED->value,
     ];
 });
 
@@ -23,19 +23,19 @@ $factory->state($chargeModel, 'test', [
 ]);
 
 $factory->state($chargeModel, 'type_recurring', [
-    'type' => ChargeType::RECURRING()->toNative(),
+    'type' => ChargeType::RECURRING->value,
 ]);
 
 $factory->state($chargeModel, 'type_onetime', [
-    'type' => ChargeType::CHARGE()->toNative(),
+    'type' => ChargeType::CHARGE->value,
 ]);
 
 $factory->state($chargeModel, 'type_usage', [
-    'type' => ChargeType::USAGE()->toNative(),
+    'type' => ChargeType::USAGE->value,
 ]);
 
 $factory->state($chargeModel, 'type_credit', [
-    'type' => ChargeType::CREDIT()->toNative(),
+    'type' => ChargeType::CREDIT->value,
 ]);
 
 $factory->state($chargeModel, 'trial', function ($faker) {

--- a/src/resources/database/factories/PlanFactory.php
+++ b/src/resources/database/factories/PlanFactory.php
@@ -37,14 +37,14 @@ $factory->state($planModel, 'installable', [
 ]);
 
 $factory->state($planModel, 'type_recurring', [
-    'type' => PlanType::RECURRING()->toNative(),
-    'interval' => PlanInterval::EVERY_30_DAYS()->toNative(),
+    'type' => PlanType::RECURRING->value,
+    'interval' => PlanInterval::EVERY_30_DAYS->value,
 ]);
 
 $factory->state($planModel, 'type_onetime', [
-    'type' => PlanType::ONETIME()->toNative(),
+    'type' => PlanType::ONETIME->value,
 ]);
 
 $factory->state($planModel, 'interval_annual', [
-    'interval' => PlanInterval::ANNUAL()->toNative(),
+    'interval' => PlanInterval::ANNUAL->value,
 ]);

--- a/tests/Actions/VerifyThemeSupportTest.php
+++ b/tests/Actions/VerifyThemeSupportTest.php
@@ -78,11 +78,9 @@ class VerifyThemeSupportTest extends TestCase
     /**
      * Create ThemeHelper stub
      *
-     * @param int $level
-     *
      * @return ThemeHelper
      */
-    protected function createThemeHelperStub(int $level): ThemeHelper
+    protected function createThemeHelperStub(ThemeSupportLevel $level): ThemeHelper
     {
         $themeHelperStub = $this->createStub(ThemeHelper::class);
 

--- a/tests/Messaging/Jobs/AppUninstalledTest.php
+++ b/tests/Messaging/Jobs/AppUninstalledTest.php
@@ -29,7 +29,7 @@ class AppUninstalledTest extends TestCase
         factory(Util::getShopifyConfig('models.charge', Charge::class))->states('type_recurring')->create([
             'plan_id' => $plan->getId()->toNative(),
             'user_id' => $shop->getId()->toNative(),
-            'status' => ChargeStatus::ACTIVE()->toNative(),
+            'status' => ChargeStatus::ACTIVE->value,
         ]);
 
         // Ensure shop is not trashed, and has charges

--- a/tests/Services/ApiHelperTest.php
+++ b/tests/Services/ApiHelperTest.php
@@ -76,7 +76,7 @@ class ApiHelperTest extends TestCase
         $shop = factory($this->model)->create();
 
         $this->assertNotEmpty(
-            $shop->apiHelper()->buildAuthUrl(AuthMode::OFFLINE(), 'read_content')
+            $shop->apiHelper()->buildAuthUrl(AuthMode::OFFLINE, 'read_content')
         );
     }
 
@@ -132,7 +132,7 @@ class ApiHelperTest extends TestCase
         $this->setApiStub();
         ApiStub::stubResponses(['get_application_charge']);
 
-        $data = $shop->apiHelper()->getCharge(ChargeType::CHARGE(), ChargeReference::fromNative(1234));
+        $data = $shop->apiHelper()->getCharge(ChargeType::CHARGE, ChargeReference::fromNative(1234));
         $this->assertInstanceOf(ResponseAccess::class, $data);
         $this->assertSame('iPod Cleaning', $data->name);
         $this->assertSame('accepted', $data['status']);
@@ -147,7 +147,7 @@ class ApiHelperTest extends TestCase
         $this->setApiStub();
         ApiStub::stubResponses(['post_recurring_application_charges_activate']);
 
-        $data = $shop->apiHelper()->activateCharge(ChargeType::RECURRING(), ChargeReference::fromNative(1234));
+        $data = $shop->apiHelper()->activateCharge(ChargeType::RECURRING, ChargeReference::fromNative(1234));
         $this->assertInstanceOf(ResponseAccess::class, $data);
         $this->assertSame('Super Mega Plan', $data['name']);
     }
@@ -165,12 +165,12 @@ class ApiHelperTest extends TestCase
         $transfer = new PlanDetailsTransfer();
         $transfer->name = 'Test';
         $transfer->price = 12.00;
-        $transfer->interval = PlanInterval::EVERY_30_DAYS()->toNative();
+        $transfer->interval = PlanInterval::EVERY_30_DAYS->value;
         $transfer->test = true;
         $transfer->trialDays = 7;
 
         $data = $shop->apiHelper()->createCharge(
-            ChargeType::RECURRING(),
+            ChargeType::RECURRING,
             $transfer
         );
         $this->assertInstanceOf(ResponseAccess::class, $data);
@@ -256,7 +256,7 @@ class ApiHelperTest extends TestCase
         $transfer = new PlanDetailsTransfer();
         $transfer->name = 'Test';
         $transfer->price = 12.00;
-        $transfer->interval = PlanInterval::ANNUAL()->toNative();
+        $transfer->interval = PlanInterval::ANNUAL->value;
         $transfer->test = true;
         $transfer->trialDays = 7;
 

--- a/tests/Services/ChargeHelperTest.php
+++ b/tests/Services/ChargeHelperTest.php
@@ -89,7 +89,7 @@ class ChargeHelperTest extends TestCase
     {
         // Seed
         $seed = $this->seedData([
-            'status' => ChargeStatus::CANCELLED()->toNative(),
+            'status' => ChargeStatus::CANCELLED->value,
             'trial_days' => 7,
             'trial_ends_on' => '2020-01-10',
             'cancelled_on' => '2020-01-05',

--- a/tests/Storage/Commands/ChargeTest.php
+++ b/tests/Storage/Commands/ChargeTest.php
@@ -94,8 +94,8 @@ class ChargeTest extends TestCase
         $charge = new ChargeTransfer();
         $charge->shopId = ShopId::fromNative(1);
         $charge->chargeReference = ChargeReference::fromNative(123456);
-        $charge->chargeType = ChargeType::RECURRING();
-        $charge->chargeStatus = ChargeStatus::ACCEPTED();
+        $charge->chargeType = ChargeType::RECURRING;
+        $charge->chargeStatus = ChargeStatus::ACCEPTED;
         $charge->planDetails = $planDetails;
         $charge->planId = PlanId::fromNative(1);
 

--- a/tests/Storage/Models/ChargeTest.php
+++ b/tests/Storage/Models/ChargeTest.php
@@ -29,8 +29,8 @@ class ChargeTest extends TestCase
         $this->assertNull($charge->plan);
         $this->assertFalse($charge->isTest());
         $this->assertFalse($charge->isTrial());
-        $this->assertTrue($charge->isType(ChargeType::RECURRING()));
-        $this->assertTrue($charge->isStatus(ChargeStatus::ACCEPTED()));
+        $this->assertTrue($charge->isType(ChargeType::RECURRING));
+        $this->assertTrue($charge->isStatus(ChargeStatus::ACCEPTED));
         $this->assertFalse($charge->isActive());
         $this->assertTrue($charge->isAccepted());
         $this->assertFalse($charge->isDeclined());

--- a/tests/Storage/Models/PlanTest.php
+++ b/tests/Storage/Models/PlanTest.php
@@ -17,8 +17,8 @@ class PlanTest extends TestCase
 
         $this->assertInstanceOf(PlanId::class, $plan->getId());
         $this->assertCount(0, $plan->charges);
-        $this->assertEquals(PlanType::RECURRING(), $plan->getType());
-        $this->assertTrue($plan->isType(PlanType::RECURRING()));
+        $this->assertEquals(PlanType::RECURRING, $plan->getType());
+        $this->assertTrue($plan->isType(PlanType::RECURRING));
         $this->assertSame('recurring_application_charge', $plan->getTypeApiString());
         $this->assertSame('recurring_application_charges', $plan->getTypeApiString(true));
         $this->assertFalse($plan->hasTrial());


### PR DESCRIPTION
This PR replaces `EnumTrait` classes, from the `funeralzone/valueobjects` package, with native PHP backed enums that were introduced in PHP 8.1, now that the package requires that version as a minimum. We still require `funeralzone/valueobjects` for Value objects (`ShopId`, `AccessToken`, `ShopDomain`, etc.). There's multiple reasons we should do this:

- Less dependency surface
- Better tooling
- Clearer semantics
- Aligned with Laravel
- Future-proof

This change will most likely have to be a major version bump. If apps reference enums directly, then they will break (update instructions at the bottom of this comment)!

### Changes

- All **11** enum classes are now native backed enums (`string` or `int` backing as appropriate)
- References updated throughout the package:
  - `ChargeStatus::ACTIVE()` is now `ChargeStatus::ACTIVE`
  - `$enum->toNative()` is now `$enum->value`
  - `$a->isSame($b)` is now `$a === $b`
- **UPPERCASE case names preserved** (e.g. `ChargeStatus::ACTIVE`, not `Active`) to minimise breaking changes. Whilst the general consensus is that enums should be CamelCase, I didn't think it was worth changing this. 
- **`fromNative()` kept but marked `@deprecated`** on all enums. Folks should use `Enum::from()` / `Enum::tryFrom()` going forward. `fromNative()` could be removed in a later version.
- **`ChargeStatus::fromShopifyApiStatus()`** retained as a domain helper

### Backing values

Enum `->value` matches legacy **`toNative()`** output (constant **name strings**), not the old internal int constants.

| Enum | Backing | Example `->value` |
|------|---------|-------------------|
| `ChargeStatus`, `PlanType`, `AuthMode`, etc. | `string` | `"ACTIVE"`, `"RECURRING"` |
| `ThemeSupportLevel`, `SessionTokenSource` | `int` | `0`, `1`, `2` |

### Breaking changes

Apps that reference package enums directly will need to update:

| Before | After |
|--------|-------|
| `ChargeStatus::ACTIVE()` | `ChargeStatus::ACTIVE` |
| `$status->toNative()` | `$status->value` |
| `$a->isSame($b)` | `$a === $b` |
| `ChargeStatus::fromNative('ACTIVE')` | `ChargeStatus::from('ACTIVE')` (deprecated shim still works for now) |