### PR TITLE
Migrate Existing Stores to Expiring Offline Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ Authorization code exchange, session-token exchange, and `refresh_token` grants 
 
 Migration is **one-way**: Shopify revokes the old token on successful exchange.
 
+**Long-running jobs:** Token refresh runs when the API client is first built (`$shop->api()` / `$shop->apiHelper()`). If a job reuses the same shop model for hours, the cached client keeps the old access token even after expiry. Options:
+
+- **Opt-in config:** `SHOPIFY_REFRESH_OFFLINE_TOKEN_BEFORE_API_CALL=true` re-checks expiry before each `api()` / `apiHelper()` call and rebuilds the client when needed.
+- **Manual helpers on your shop model:**
+  - `$shop->offlineAccessTokenIsFresh()` — `true` when the token is outside the refresh skew window
+  - `$shop->refreshOfflineAccessTokenIfNeeded()` — refreshes via Shopify and clears the cached client
+  - `$shop->resetApiClient()` — clears the cached client so the next API call rebuilds it
+
+```php
+// Per loop iteration in a bulk job
+if (! $shop->offlineAccessTokenIsFresh()) {
+    $shop->refreshOfflineAccessTokenIfNeeded();
+}
+$shop->api()->graph('...');
+```
+
 If your `User` model overrides `$casts`, merge `datetime` casts for the two `*_expires_at` columns (the `ShopModel` trait uses `mergeCasts` when `initializeShopModel` runs).
 
 Longer term, consider replacing or forking `gnikyt/basic-shopify-api` for REST/Graph traffic if you need an actively maintained HTTP client; expiring offline OAuth is already decoupled from that dependency.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ For full resources on this package, see the [wiki](../..//wiki).
 
 Authorization code exchange, session-token exchange, and `refresh_token` grants are handled inside this package (`Osiset\ShopifyApp\Services\ApiHelper` and `OfflineAccessTokenRefresher`), not via `gnikyt/basic-shopify-api` updates. A valid access token is refreshed automatically before `apiHelper()` builds the API session when the offline token is expired or within the configured skew.
 
+**Migrating existing installs (optional):** Shops that already have a non-expiring offline token are not upgraded automatically when you enable the flag. To migrate without merchant re-auth, use Shopify [Step 4: token exchange](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens):
+
+- **API:** `ApiHelper::exchangeNonExpiringOfflineTokenForExpiring($shopDomain, $currentOfflineToken)` then persist with `ShopCommand::setAccessToken` (or use the action below).
+- **Action:** `MigrateShopToExpiringOfflineAccessToken` — call per shop from your own job or on next app launch; returns `migrated`, `skipped`, `reason`, and `error` keys.
+- **CLI (optional):** `php artisan shopify-app:migrate-expiring-offline-tokens` (`--dry-run`, `--shop=example.myshopify.com`). Migration is **one-way**: Shopify revokes the old token on success.
+
 If your `User` model overrides `$casts`, merge `datetime` casts for the two `*_expires_at` columns (the `ShopModel` trait uses `mergeCasts` when `initializeShopModel` runs).
 
 Longer term, consider replacing or forking `gnikyt/basic-shopify-api` for REST/Graph traffic if you need an actively maintained HTTP client; expiring offline OAuth is already decoupled from that dependency.

--- a/README.md
+++ b/README.md
@@ -54,16 +54,19 @@ For full resources on this package, see the [wiki](../..//wiki).
 [Shopify requires expiring offline access tokens](https://shopify.dev/changelog/expiring-offline-access-tokens-required-for-public-apps-april-1-2026) for **new public apps** created on or after April 1, 2026. This package supports them when enabled:
 
 1. Run package migrations so your shops table includes `shopify_offline_refresh_token`, `shopify_offline_access_token_expires_at`, and `shopify_offline_refresh_token_expires_at`.
-2. Set `SHOPIFY_EXPIRING_OFFLINE_TOKENS=true` in `.env` (see `expiring_offline_tokens` and `offline_access_token_refresh_skew_seconds` in `config/shopify-app.php`).
+2. Set `SHOPIFY_EXPIRING_OFFLINE_TOKENS=true` in `.env` (see `expiring_offline_tokens`, `auto_migrate_legacy`, and `offline_access_token_refresh_skew_seconds` in `config/shopify-app.php`).
 3. Keep `APP_KEY` stable: refresh tokens are stored encrypted with Laravel’s encrypter.
 
 Authorization code exchange, session-token exchange, and `refresh_token` grants are handled inside this package (`Osiset\ShopifyApp\Services\ApiHelper` and `OfflineAccessTokenRefresher`), not via `gnikyt/basic-shopify-api` updates. A valid access token is refreshed automatically before `apiHelper()` builds the API session when the offline token is expired or within the configured skew.
 
-**Migrating existing installs (optional):** Shops that already have a non-expiring offline token are not upgraded automatically when you enable the flag. To migrate without merchant re-auth, use Shopify [Step 4: token exchange](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens):
+**Migrating existing installs (optional):** Shops that already have a non-expiring offline token are not upgraded automatically when you enable the flag alone. Options:
 
-- **API:** `ApiHelper::exchangeNonExpiringOfflineTokenForExpiring($shopDomain, $currentOfflineToken)` then persist with `ShopCommand::setAccessToken` (or use the action below).
-- **Action:** `MigrateShopToExpiringOfflineAccessToken` — call per shop from your own job or on next app launch; returns `migrated`, `skipped`, `reason`, and `error` keys.
-- **CLI (optional):** `php artisan shopify-app:migrate-expiring-offline-tokens` (`--dry-run`, `--shop=example.myshopify.com`). Migration is **one-way**: Shopify revokes the old token on success.
+- **Passive (default):** With `SHOPIFY_AUTO_MIGRATE_LEGACY=true` (default), the first `apiHelper()` call for a legacy shop runs Shopify [Step 4](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens) token exchange synchronously. Failures are logged and the request continues with the legacy token (fail-open).
+- **Batch CLI (serverless-safe):** `php artisan shopify-app:migrate-expiring-offline-tokens` (`--dry-run`, `--shop=example.myshopify.com`) chunks matching shops and dispatches `MigrateShopTokenJob` to the queue — no HTTP in the command itself (suitable for Laravel Vapor).
+- **Action:** `MigrateShopToExpiringOfflineAccessToken` — call per shop from your own code; returns `migrated`, `skipped`, `reason`, and `error` keys.
+- **API:** `ApiHelper::exchangeNonExpiringOfflineTokenForExpiring($shopDomain, $currentOfflineToken)` then persist with `ShopCommand::setAccessToken`.
+
+Migration is **one-way**: Shopify revokes the old token on successful exchange.
 
 If your `User` model overrides `$casts`, merge `datetime` casts for the two `*_expires_at` columns (the `ShopModel` trait uses `mergeCasts` when `initializeShopModel` runs).
 

--- a/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
+++ b/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
@@ -11,6 +11,7 @@ You are enabling or operating **Shopify expiring offline access tokens** in **yo
 
 - `SHOPIFY_EXPIRING_OFFLINE_TOKENS` → `expiring_offline_tokens` — when `true`, new offline exchanges use refresh-token rotation per Shopify’s model.
 - `SHOPIFY_AUTO_MIGRATE_LEGACY` → `auto_migrate_legacy` — when `true` (default), legacy shops are migrated on-the-fly before the first `apiHelper()` call; failures fail open (logged warning, legacy token kept).
+- `SHOPIFY_REFRESH_OFFLINE_TOKEN_BEFORE_API_CALL` → `refresh_offline_token_before_api_call` — when `true`, each `api()` / `apiHelper()` call re-checks token expiry and rebuilds the cached client if within the refresh skew (for long-running jobs).
 - `SHOPIFY_OFFLINE_ACCESS_TOKEN_REFRESH_SKEW` → `offline_access_token_refresh_skew_seconds` — refresh this many seconds **before** access token expiry.
 
 Read the package README for policy notes (e.g. public apps after Shopify’s cutoff dates).
@@ -28,6 +29,8 @@ If you override `$casts` on **your** shop model, merge with the package trait’
 ## Runtime behavior (reference)
 
 - Token refresh is coordinated through `ApiHelper` and `OfflineAccessTokenRefresher` in the package — you normally do not call these directly from app code; ensure shops use `apiHelper()` (or equivalent documented entry points) so refresh runs when needed.
+- The API client is **memoized** on the shop model. Long-running jobs that reuse one instance across token expiry must either enable `refresh_offline_token_before_api_call` or call `$shop->refreshOfflineAccessTokenIfNeeded()` / `$shop->resetApiClient()` before subsequent API calls.
+- Shop helpers: `offlineAccessTokenIsFresh()`, `refreshOfflineAccessTokenIfNeeded()`, `resetApiClient()`.
 - Refresh failures throw `Osiset\ShopifyApp\Exceptions\OAuthTokenRefreshException` — handle or log in **your** exception reporting so ops can re-authenticate affected shops.
 
 ## Migrating existing shops (optional)

--- a/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
+++ b/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
@@ -10,6 +10,7 @@ You are enabling or operating **Shopify expiring offline access tokens** in **yo
 ## Configuration (your published `shopify-app.php`)
 
 - `SHOPIFY_EXPIRING_OFFLINE_TOKENS` → `expiring_offline_tokens` — when `true`, new offline exchanges use refresh-token rotation per Shopify’s model.
+- `SHOPIFY_AUTO_MIGRATE_LEGACY` → `auto_migrate_legacy` — when `true` (default), legacy shops are migrated on-the-fly before the first `apiHelper()` call; failures fail open (logged warning, legacy token kept).
 - `SHOPIFY_OFFLINE_ACCESS_TOKEN_REFRESH_SKEW` → `offline_access_token_refresh_skew_seconds` — refresh this many seconds **before** access token expiry.
 
 Read the package README for policy notes (e.g. public apps after Shopify’s cutoff dates).
@@ -33,9 +34,11 @@ If you override `$casts` on **your** shop model, merge with the package trait’
 
 Enabling the flag does **not** upgrade shops that only have a legacy non-expiring token. Use one of:
 
-- **`Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken`** — invoke per shop from your job or middleware; inspect `migrated`, `skipped`, `reason`, `error` in the returned array.
+- **Passive (default):** `auto_migrate_legacy` — first `apiHelper()` call runs Step 4 exchange; failures are logged and the legacy token is used (no downtime).
+- **`Osiset\ShopifyApp\Messaging\Jobs\MigrateShopTokenJob`** — dispatched by the Artisan command or your own scheduler; one shop per job.
+- **`Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken`** — invoke per shop from your code; inspect `migrated`, `skipped`, `reason`, `error` in the returned array.
 - **`ApiHelper::exchangeNonExpiringOfflineTokenForExpiring($shopDomain, $currentToken)`** — [Shopify Step 4](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens) token exchange; then persist via `ShopCommand::setAccessToken` with refresh + expiry fields.
-- **`php artisan shopify-app:migrate-expiring-offline-tokens`** — optional package CLI (`--dry-run`, `--shop=`). Success revokes the old offline token (one-way).
+- **`php artisan shopify-app:migrate-expiring-offline-tokens`** — optional CLI (`--dry-run`, `--shop=`). Chunks shops and dispatches queue jobs (Vapor/serverless-safe). Success revokes the old offline token (one-way).
 
 Alternative: merchant re-auth (OAuth or session token exchange) also acquires expiring tokens when the flag is on.
 

--- a/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
+++ b/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
@@ -29,6 +29,16 @@ If you override `$casts` on **your** shop model, merge with the package trait’
 - Token refresh is coordinated through `ApiHelper` and `OfflineAccessTokenRefresher` in the package — you normally do not call these directly from app code; ensure shops use `apiHelper()` (or equivalent documented entry points) so refresh runs when needed.
 - Refresh failures throw `Osiset\ShopifyApp\Exceptions\OAuthTokenRefreshException` — handle or log in **your** exception reporting so ops can re-authenticate affected shops.
 
+## Migrating existing shops (optional)
+
+Enabling the flag does **not** upgrade shops that only have a legacy non-expiring token. Use one of:
+
+- **`Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken`** — invoke per shop from your job or middleware; inspect `migrated`, `skipped`, `reason`, `error` in the returned array.
+- **`ApiHelper::exchangeNonExpiringOfflineTokenForExpiring($shopDomain, $currentToken)`** — [Shopify Step 4](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens) token exchange; then persist via `ShopCommand::setAccessToken` with refresh + expiry fields.
+- **`php artisan shopify-app:migrate-expiring-offline-tokens`** — optional package CLI (`--dry-run`, `--shop=`). Success revokes the old offline token (one-way).
+
+Alternative: merchant re-auth (OAuth or session token exchange) also acquires expiring tokens when the flag is on.
+
 ## Operational notes
 
 - Keep **`APP_KEY` stable** in each environment; encrypted column values depend on it.

--- a/src/Actions/InstallShop.php
+++ b/src/Actions/InstallShop.php
@@ -3,7 +3,9 @@
 namespace Osiset\ShopifyApp\Actions;
 
 use Exception;
+use Gnikyt\BasicShopifyAPI\Session;
 use Illuminate\Support\Carbon;
+use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
 use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
@@ -20,6 +22,7 @@ class InstallShop
     public function __construct(
         protected IShopQuery $shopQuery,
         protected IShopCommand $shopCommand,
+        protected IApiHelper $apiHelper,
         protected VerifyThemeSupport $verifyThemeSupport
     ) {
     }
@@ -33,7 +36,10 @@ class InstallShop
             $shop = $this->shopQuery->getByDomain($shopDomain);
         }
 
-        $apiHelper = $shop->apiHelper();
+        $apiHelper = $this->apiHelper->make(new Session(
+            $shop->getDomain()->toNative(),
+            $shop->getAccessToken()->toNative()
+        ));
         $grantMode = $shop->hasOfflineAccess()
             ? AuthMode::fromNative(Util::getShopifyConfig('api_grant_mode', $shop))
             : AuthMode::OFFLINE();

--- a/src/Actions/MigrateShopToExpiringOfflineAccessToken.php
+++ b/src/Actions/MigrateShopToExpiringOfflineAccessToken.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Osiset\ShopifyApp\Actions;
+
+use Exception;
+use Illuminate\Support\Carbon;
+use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
+use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
+use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
+use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
+use Osiset\ShopifyApp\Objects\Values\AccessToken;
+use Osiset\ShopifyApp\Objects\Values\ShopId;
+use Osiset\ShopifyApp\Util;
+
+/**
+ * Optionally migrate a shop from a non-expiring offline token to Shopify expiring offline tokens.
+ *
+ * @link https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens
+ */
+class MigrateShopToExpiringOfflineAccessToken
+{
+    public const REASON_ALREADY_EXPIRING = 'already_expiring';
+
+    public const REASON_FEATURE_DISABLED = 'expiring_offline_tokens_disabled';
+
+    public const REASON_NO_OFFLINE_TOKEN = 'no_offline_access_token';
+
+    public const REASON_SHOP_NOT_FOUND = 'shop_not_found';
+
+    public function __construct(
+        protected IShopQuery $shopQuery,
+        protected IShopCommand $shopCommand,
+        protected IApiHelper $apiHelper
+    ) {
+    }
+
+    /**
+     * @param IShopModel|ShopId $shopOrId
+     *
+     * @return array{migrated: bool, skipped: bool, reason: string|null, shop_id: int|null, error: string|null}
+     */
+    public function __invoke(IShopModel|ShopId $shopOrId): array
+    {
+        $shop = $shopOrId instanceof ShopId
+            ? $this->shopQuery->getById($shopOrId)
+            : $shopOrId;
+
+        if ($shop === null) {
+            return $this->result(skipped: true, reason: self::REASON_SHOP_NOT_FOUND);
+        }
+
+        if (! Util::getShopifyConfig('expiring_offline_tokens', $shop)) {
+            return $this->result(skipped: true, reason: self::REASON_FEATURE_DISABLED, shopId: $shop->getId()->toNative());
+        }
+
+        if ($shop->hasExpiringOfflineAccess()) {
+            return $this->result(skipped: true, reason: self::REASON_ALREADY_EXPIRING, shopId: $shop->getId()->toNative());
+        }
+
+        if (! $shop->hasOfflineAccess()) {
+            return $this->result(skipped: true, reason: self::REASON_NO_OFFLINE_TOKEN, shopId: $shop->getId()->toNative());
+        }
+
+        try {
+            $data = $this->apiHelper->exchangeNonExpiringOfflineTokenForExpiring(
+                $shop->getDomain()->toNative(),
+                $shop->getAccessToken()->toNative()
+            );
+
+            if (! isset($data['refresh_token'], $data['access_token'], $data['expires_in'], $data['refresh_token_expires_in'])) {
+                return $this->result(
+                    shopId: $shop->getId()->toNative(),
+                    error: 'Invalid token exchange response from Shopify.'
+                );
+            }
+
+            $this->shopCommand->setAccessToken(
+                $shop->getId(),
+                AccessToken::fromNative($data['access_token']),
+                $data['refresh_token'],
+                Carbon::now()->addSeconds((int) $data['expires_in']),
+                Carbon::now()->addSeconds((int) $data['refresh_token_expires_in'])
+            );
+
+            return $this->result(migrated: true, shopId: $shop->getId()->toNative());
+        } catch (Exception $e) {
+            return $this->result(shopId: $shop->getId()->toNative(), error: $e->getMessage());
+        }
+    }
+
+    /**
+     * @return array{migrated: bool, skipped: bool, reason: string|null, shop_id: int|null, error: string|null}
+     */
+    protected function result(
+        bool $migrated = false,
+        bool $skipped = false,
+        ?string $reason = null,
+        ?int $shopId = null,
+        ?string $error = null
+    ): array {
+        return [
+            'migrated' => $migrated,
+            'skipped' => $skipped,
+            'reason' => $reason,
+            'shop_id' => $shopId,
+            'error' => $error,
+        ];
+    }
+}

--- a/src/Actions/MigrateShopToExpiringOfflineAccessToken.php
+++ b/src/Actions/MigrateShopToExpiringOfflineAccessToken.php
@@ -4,6 +4,7 @@ namespace Osiset\ShopifyApp\Actions;
 
 use Exception;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Commands\Shop as IShopCommand;
 use Osiset\ShopifyApp\Contracts\Queries\Shop as IShopQuery;
@@ -61,31 +62,67 @@ class MigrateShopToExpiringOfflineAccessToken
             return $this->result(skipped: true, reason: self::REASON_NO_OFFLINE_TOKEN, shopId: $shop->getId()->toNative());
         }
 
-        try {
-            $data = $this->apiHelper->exchangeNonExpiringOfflineTokenForExpiring(
-                $shop->getDomain()->toNative(),
-                $shop->getAccessToken()->toNative()
-            );
+        $result = [
+            'migrated' => false,
+            'skipped' => false,
+            'reason' => null,
+            'shop_id' => $shop->getId()->toNative(),
+            'error' => null,
+        ];
 
-            if (! isset($data['refresh_token'], $data['access_token'], $data['expires_in'], $data['refresh_token_expires_in'])) {
-                return $this->result(
-                    shopId: $shop->getId()->toNative(),
-                    error: 'Invalid token exchange response from Shopify.'
+        Cache::lock('shopify-offline-migrate:'.$shop->getId()->toNative(), 30)->block(10, function () use ($shop, &$result) {
+            $shop->refresh();
+
+            if ($shop->hasExpiringOfflineAccess()) {
+                $result = $this->result(
+                    skipped: true,
+                    reason: self::REASON_ALREADY_EXPIRING,
+                    shopId: $shop->getId()->toNative()
                 );
+
+                return;
             }
 
-            $this->shopCommand->setAccessToken(
-                $shop->getId(),
-                AccessToken::fromNative($data['access_token']),
-                $data['refresh_token'],
-                Carbon::now()->addSeconds((int) $data['expires_in']),
-                Carbon::now()->addSeconds((int) $data['refresh_token_expires_in'])
-            );
+            if (! $shop->hasOfflineAccess()) {
+                $result = $this->result(
+                    skipped: true,
+                    reason: self::REASON_NO_OFFLINE_TOKEN,
+                    shopId: $shop->getId()->toNative()
+                );
 
-            return $this->result(migrated: true, shopId: $shop->getId()->toNative());
-        } catch (Exception $e) {
-            return $this->result(shopId: $shop->getId()->toNative(), error: $e->getMessage());
-        }
+                return;
+            }
+
+            try {
+                $data = $this->apiHelper->exchangeNonExpiringOfflineTokenForExpiring(
+                    $shop->getDomain()->toNative(),
+                    $shop->getAccessToken()->toNative()
+                );
+
+                if (! isset($data['refresh_token'], $data['access_token'], $data['expires_in'], $data['refresh_token_expires_in'])) {
+                    $result = $this->result(
+                        shopId: $shop->getId()->toNative(),
+                        error: 'Invalid token exchange response from Shopify.'
+                    );
+
+                    return;
+                }
+
+                $this->shopCommand->setAccessToken(
+                    $shop->getId(),
+                    AccessToken::fromNative($data['access_token']),
+                    $data['refresh_token'],
+                    Carbon::now()->addSeconds((int) $data['expires_in']),
+                    Carbon::now()->addSeconds((int) $data['refresh_token_expires_in'])
+                );
+
+                $result = $this->result(migrated: true, shopId: $shop->getId()->toNative());
+            } catch (Exception $e) {
+                $result = $this->result(shopId: $shop->getId()->toNative(), error: $e->getMessage());
+            }
+        });
+
+        return $result;
     }
 
     /**

--- a/src/Console/MigrateExpiringOfflineTokensCommand.php
+++ b/src/Console/MigrateExpiringOfflineTokensCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Osiset\ShopifyApp\Console;
+
+use Illuminate\Console\Command;
+use Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken;
+use Osiset\ShopifyApp\Util;
+
+class MigrateExpiringOfflineTokensCommand extends Command
+{
+    protected $signature = 'shopify-app:migrate-expiring-offline-tokens
+        {--shop= : Migrate a single shop by domain (e.g. example.myshopify.com)}
+        {--dry-run : List shops that would be migrated without calling Shopify}';
+
+    protected $description = 'Migrate legacy non-expiring offline tokens to expiring offline tokens (optional; requires SHOPIFY_EXPIRING_OFFLINE_TOKENS)';
+
+    public function handle(MigrateShopToExpiringOfflineAccessToken $migrate): int
+    {
+        if (! Util::getShopifyConfig('expiring_offline_tokens')) {
+            $this->error('expiring_offline_tokens is disabled. Set SHOPIFY_EXPIRING_OFFLINE_TOKENS=true first.');
+
+            return self::FAILURE;
+        }
+
+        $modelClass = Util::getShopifyConfig('user_model');
+        $shopDomain = $this->option('shop');
+
+        $query = $modelClass::query()
+            ->whereNotNull('password')
+            ->where('password', '!=', '')
+            ->where(function ($q) {
+                $q->whereNull('shopify_offline_refresh_token')
+                    ->orWhere('shopify_offline_refresh_token', '');
+            });
+
+        if ($shopDomain) {
+            $query->where('name', $shopDomain);
+        }
+
+        $shops = $query->get();
+
+        if ($shops->isEmpty()) {
+            $this->info('No shops need migration.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — shops that would be migrated:');
+            foreach ($shops as $shop) {
+                $this->line('  - '.$shop->name.' (id: '.$shop->id.')');
+            }
+
+            return self::SUCCESS;
+        }
+
+        $migrated = 0;
+        $skipped = 0;
+        $failed = 0;
+
+        foreach ($shops as $shop) {
+            $result = $migrate($shop);
+
+            if ($result['migrated']) {
+                $migrated++;
+                $this->info("Migrated: {$shop->name}");
+
+                continue;
+            }
+
+            if ($result['skipped']) {
+                $skipped++;
+                $this->line("Skipped: {$shop->name} ({$result['reason']})");
+
+                continue;
+            }
+
+            $failed++;
+            $this->error("Failed: {$shop->name} — {$result['error']}");
+        }
+
+        $this->newLine();
+        $this->info("Done. Migrated: {$migrated}, skipped: {$skipped}, failed: {$failed}.");
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/src/Console/MigrateExpiringOfflineTokensCommand.php
+++ b/src/Console/MigrateExpiringOfflineTokensCommand.php
@@ -3,18 +3,18 @@
 namespace Osiset\ShopifyApp\Console;
 
 use Illuminate\Console\Command;
-use Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken;
+use Osiset\ShopifyApp\Messaging\Jobs\MigrateShopTokenJob;
 use Osiset\ShopifyApp\Util;
 
 class MigrateExpiringOfflineTokensCommand extends Command
 {
     protected $signature = 'shopify-app:migrate-expiring-offline-tokens
         {--shop= : Migrate a single shop by domain (e.g. example.myshopify.com)}
-        {--dry-run : List shops that would be migrated without calling Shopify}';
+        {--dry-run : List shops that would be migrated without dispatching jobs}';
 
-    protected $description = 'Migrate legacy non-expiring offline tokens to expiring offline tokens (optional; requires SHOPIFY_EXPIRING_OFFLINE_TOKENS)';
+    protected $description = 'Dispatch queue jobs to migrate legacy non-expiring offline tokens to expiring offline tokens (optional; requires SHOPIFY_EXPIRING_OFFLINE_TOKENS)';
 
-    public function handle(MigrateShopToExpiringOfflineAccessToken $migrate): int
+    public function handle(): int
     {
         if (! Util::getShopifyConfig('expiring_offline_tokens')) {
             $this->error('expiring_offline_tokens is disabled. Set SHOPIFY_EXPIRING_OFFLINE_TOKENS=true first.');
@@ -37,51 +37,41 @@ class MigrateExpiringOfflineTokensCommand extends Command
             $query->where('name', $shopDomain);
         }
 
-        $shops = $query->get();
+        if ($this->option('dry-run')) {
+            $count = 0;
+            $query->chunk(100, function ($shops) use (&$count) {
+                foreach ($shops as $shop) {
+                    $this->line('  - '.$shop->name.' (id: '.$shop->id.')');
+                    $count++;
+                }
+            });
 
-        if ($shops->isEmpty()) {
+            if ($count === 0) {
+                $this->info('No shops need migration.');
+            } else {
+                $this->info("Dry run — {$count} shop(s) would be migrated.");
+            }
+
+            return self::SUCCESS;
+        }
+
+        $dispatched = 0;
+
+        $query->chunk(100, function ($shops) use (&$dispatched) {
+            foreach ($shops as $shop) {
+                MigrateShopTokenJob::dispatch($shop);
+                $dispatched++;
+            }
+        });
+
+        if ($dispatched === 0) {
             $this->info('No shops need migration.');
 
             return self::SUCCESS;
         }
 
-        if ($this->option('dry-run')) {
-            $this->info('Dry run — shops that would be migrated:');
-            foreach ($shops as $shop) {
-                $this->line('  - '.$shop->name.' (id: '.$shop->id.')');
-            }
+        $this->info("Dispatched {$dispatched} migration job(s).");
 
-            return self::SUCCESS;
-        }
-
-        $migrated = 0;
-        $skipped = 0;
-        $failed = 0;
-
-        foreach ($shops as $shop) {
-            $result = $migrate($shop);
-
-            if ($result['migrated']) {
-                $migrated++;
-                $this->info("Migrated: {$shop->name}");
-
-                continue;
-            }
-
-            if ($result['skipped']) {
-                $skipped++;
-                $this->line("Skipped: {$shop->name} ({$result['reason']})");
-
-                continue;
-            }
-
-            $failed++;
-            $this->error("Failed: {$shop->name} — {$result['error']}");
-        }
-
-        $this->newLine();
-        $this->info("Done. Migrated: {$migrated}, skipped: {$skipped}, failed: {$failed}.");
-
-        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+        return self::SUCCESS;
     }
 }

--- a/src/Contracts/ApiHelper.php
+++ b/src/Contracts/ApiHelper.php
@@ -94,6 +94,21 @@ interface ApiHelper
     public function refreshOfflineAccessToken(string $refreshToken): ResponseAccess;
 
     /**
+     * Exchange a non-expiring offline access token for an expiring one (one-way per shop).
+     *
+     * @link https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens
+     *
+     * @param string $shopDomain                  The shop domain (e.g. example.myshopify.com).
+     * @param string $nonExpiringOfflineAccessToken The current permanent offline access token.
+     *
+     * @return ResponseAccess
+     */
+    public function exchangeNonExpiringOfflineTokenForExpiring(
+        string $shopDomain,
+        string $nonExpiringOfflineAccessToken
+    ): ResponseAccess;
+
+    /**
      * Get the script tags for the shop.
      *
      * @param array $params The params to set to the request.

--- a/src/Contracts/ShopModel.php
+++ b/src/Contracts/ShopModel.php
@@ -81,6 +81,27 @@ interface ShopModel extends Authenticatable
     public function hasExpiringOfflineAccess(): bool;
 
     /**
+     * Whether the offline access token is still valid (outside the refresh skew window).
+     *
+     * @return bool
+     */
+    public function offlineAccessTokenIsFresh(): bool;
+
+    /**
+     * Refresh the offline access token if needed and discard the cached API client.
+     *
+     * @return void
+     */
+    public function refreshOfflineAccessTokenIfNeeded(): void;
+
+    /**
+     * Discard the cached API client so the next api()/apiHelper() call rebuilds it.
+     *
+     * @return void
+     */
+    public function resetApiClient(): void;
+
+    /**
      * Get the API helper instance for a shop.
      * TODO: Find a better way than using resolve(). However, we can't inject in model constructors.
      *

--- a/src/Messaging/Jobs/MigrateShopTokenJob.php
+++ b/src/Messaging/Jobs/MigrateShopTokenJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Osiset\ShopifyApp\Messaging\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken;
+use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
+use RuntimeException;
+
+/**
+ * Queue job to migrate a single shop from a legacy offline token to expiring offline tokens.
+ */
+class MigrateShopTokenJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @param IShopModel $shop
+     */
+    public function __construct(protected IShopModel $shop)
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(MigrateShopToExpiringOfflineAccessToken $migrate): void
+    {
+        $result = $migrate($this->shop);
+
+        if ($result['error'] !== null) {
+            throw new RuntimeException($result['error']);
+        }
+    }
+}

--- a/src/Services/ApiHelper.php
+++ b/src/Services/ApiHelper.php
@@ -205,6 +205,26 @@ class ApiHelper implements IApiHelper
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function exchangeNonExpiringOfflineTokenForExpiring(
+        string $shopDomain,
+        string $nonExpiringOfflineAccessToken
+    ): ResponseAccess {
+        $this->make(new Session($shopDomain, $nonExpiringOfflineAccessToken));
+
+        return $this->oauthAccessTokenPost([
+            'client_id' => $this->api->getOptions()->getApiKey(),
+            'client_secret' => $this->api->getOptions()->getApiSecret(),
+            'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange',
+            'subject_token' => $nonExpiringOfflineAccessToken,
+            'subject_token_type' => 'urn:shopify:params:oauth:token-type:offline-access-token',
+            'requested_token_type' => 'urn:shopify:params:oauth:token-type:offline-access-token',
+            'expiring' => 1,
+        ]);
+    }
+
+    /**
      * POST /admin/oauth/access_token (JSON body).
      *
      * @param array $json

--- a/src/Services/OfflineAccessTokenRefresher.php
+++ b/src/Services/OfflineAccessTokenRefresher.php
@@ -43,14 +43,14 @@ class OfflineAccessTokenRefresher
             return;
         }
 
-        if (! $this->accessTokenNeedsRefresh($shop)) {
+        if (! $this->offlineAccessTokenNeedsRefresh($shop)) {
             return;
         }
 
         Cache::lock('shopify-offline-token:'.$shop->getId()->toNative(), 30)->block(10, function () use ($shop) {
             $shop->refresh();
 
-            if (! $this->accessTokenNeedsRefresh($shop)) {
+            if (! $this->offlineAccessTokenNeedsRefresh($shop)) {
                 return;
             }
 
@@ -96,8 +96,23 @@ class OfflineAccessTokenRefresher
         });
     }
 
-    protected function accessTokenNeedsRefresh(ShopModel $shop): bool
+    /**
+     * Whether the shop's offline access token is expired or within the refresh skew window.
+     *
+     * @param ShopModel $shop
+     *
+     * @return bool
+     */
+    public function offlineAccessTokenNeedsRefresh(ShopModel $shop): bool
     {
+        if (! Util::getShopifyConfig('expiring_offline_tokens', $shop)) {
+            return false;
+        }
+
+        if (! $shop->hasExpiringOfflineAccess()) {
+            return false;
+        }
+
         $expiresAt = $shop->shopify_offline_access_token_expires_at ?? null;
         if ($expiresAt === null) {
             return false;

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -140,6 +140,7 @@ class ShopifyAppProvider extends ServiceProvider
             return new InstallShopAction(
                 $app->make(IShopQuery::class),
                 $app->make(IShopCommand::class),
+                $app->make(IApiHelper::class),
                 $app->make(VerifyThemeSupportAction::class)
             );
         });

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -22,6 +22,7 @@ use Osiset\ShopifyApp\Actions\GetPlanUrl as GetPlanUrlAction;
 use Osiset\ShopifyApp\Actions\InstallShop as InstallShopAction;
 use Osiset\ShopifyApp\Actions\VerifyThemeSupport as VerifyThemeSupportAction;
 use Osiset\ShopifyApp\Console\AddVariablesCommand;
+use Osiset\ShopifyApp\Console\MigrateExpiringOfflineTokensCommand;
 use Osiset\ShopifyApp\Console\WebhookJobMakeCommand;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Commands\Charge as IChargeCommand;
@@ -89,6 +90,7 @@ class ShopifyAppProvider extends ServiceProvider
 
         $this->commands([
             AddVariablesCommand::class,
+            MigrateExpiringOfflineTokensCommand::class,
             WebhookJobMakeCommand::class,
         ]);
 

--- a/src/Traits/ShopModel.php
+++ b/src/Traits/ShopModel.php
@@ -7,6 +7,8 @@ use Gnikyt\BasicShopifyAPI\Session;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Log;
+use Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Objects\Values\AccessToken as AccessTokenValue;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain as ShopDomainValue;
@@ -178,6 +180,22 @@ trait ShopModel
     public function apiHelper(): IApiHelper
     {
         if ($this->apiHelper === null) {
+            if (Util::getShopifyConfig('auto_migrate_legacy', $this)
+                && Util::getShopifyConfig('expiring_offline_tokens', $this)
+                && ! $this->hasExpiringOfflineAccess()
+                && $this->hasOfflineAccess()
+            ) {
+                try {
+                    app(MigrateShopToExpiringOfflineAccessToken::class)($this);
+                    $this->refresh();
+                } catch (\Throwable $e) {
+                    Log::warning('On-the-fly Shopify offline token migration failed.', [
+                        'shop' => $this->getDomain()->toNative(),
+                        'message' => $e->getMessage(),
+                    ]);
+                }
+            }
+
             app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($this);
 
             // Set the session

--- a/src/Traits/ShopModel.php
+++ b/src/Traits/ShopModel.php
@@ -177,34 +177,34 @@ trait ShopModel
     /**
      * {@inheritdoc}
      */
+    public function offlineAccessTokenIsFresh(): bool
+    {
+        return ! app(OfflineAccessTokenRefresher::class)->offlineAccessTokenNeedsRefresh($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshOfflineAccessTokenIfNeeded(): void
+    {
+        app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($this);
+        $this->resetApiClient();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetApiClient(): void
+    {
+        $this->apiHelper = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function apiHelper(): IApiHelper
     {
-        if ($this->apiHelper === null) {
-            if (Util::getShopifyConfig('auto_migrate_legacy', $this)
-                && Util::getShopifyConfig('expiring_offline_tokens', $this)
-                && ! $this->hasExpiringOfflineAccess()
-                && $this->hasOfflineAccess()
-            ) {
-                try {
-                    app(MigrateShopToExpiringOfflineAccessToken::class)($this);
-                    $this->refresh();
-                } catch (\Throwable $e) {
-                    Log::warning('On-the-fly Shopify offline token migration failed.', [
-                        'shop' => $this->getDomain()->toNative(),
-                        'message' => $e->getMessage(),
-                    ]);
-                }
-            }
-
-            app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($this);
-
-            // Set the session
-            $session = new Session(
-                $this->getDomain()->toNative(),
-                $this->getAccessToken()->toNative()
-            );
-            $this->apiHelper = resolve(IApiHelper::class)->make($session);
-        }
+        $this->ensureApiClientIsReady();
 
         return $this->apiHelper;
     }
@@ -214,10 +214,59 @@ trait ShopModel
      */
     public function api(): BasicShopifyAPI
     {
-        if ($this->apiHelper === null) {
-            $this->apiHelper();
-        }
+        $this->ensureApiClientIsReady();
 
         return $this->apiHelper->getApi();
+    }
+
+    /**
+     * Re-check token expiry and rebuild the cached client when configured or not yet built.
+     *
+     * @return void
+     */
+    protected function ensureApiClientIsReady(): void
+    {
+        if (Util::getShopifyConfig('refresh_offline_token_before_api_call', $this)
+            && $this->apiHelper !== null
+            && app(OfflineAccessTokenRefresher::class)->offlineAccessTokenNeedsRefresh($this)
+        ) {
+            $this->resetApiClient();
+        }
+
+        if ($this->apiHelper === null) {
+            $this->buildApiHelper();
+        }
+    }
+
+    /**
+     * Build the API helper with lazy migration, token refresh, and a fresh session.
+     *
+     * @return void
+     */
+    protected function buildApiHelper(): void
+    {
+        if (Util::getShopifyConfig('auto_migrate_legacy', $this)
+            && Util::getShopifyConfig('expiring_offline_tokens', $this)
+            && ! $this->hasExpiringOfflineAccess()
+            && $this->hasOfflineAccess()
+        ) {
+            try {
+                app(MigrateShopToExpiringOfflineAccessToken::class)($this);
+                $this->refresh();
+            } catch (\Throwable $e) {
+                Log::warning('On-the-fly Shopify offline token migration failed.', [
+                    'shop' => $this->getDomain()->toNative(),
+                    'message' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($this);
+
+        $session = new Session(
+            $this->getDomain()->toNative(),
+            $this->getAccessToken()->toNative()
+        );
+        $this->apiHelper = resolve(IApiHelper::class)->make($session);
     }
 }

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -226,6 +226,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Auto-migrate legacy offline tokens
+    |--------------------------------------------------------------------------
+    |
+    | When true (and expiring_offline_tokens is enabled), shops with a legacy
+    | non-expiring offline token are migrated to expiring tokens on-the-fly
+    | before the first API call via apiHelper(). Failures are logged and the
+    | request continues with the legacy token. Disable to require explicit
+    | migration via the Artisan command or MigrateShopToExpiringOfflineAccessToken.
+    |
+    */
+
+    'auto_migrate_legacy' => (bool) env('SHOPIFY_AUTO_MIGRATE_LEGACY', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Offline access token refresh skew (seconds)
     |--------------------------------------------------------------------------
     |

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -252,6 +252,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Refresh offline token before each API call
+    |--------------------------------------------------------------------------
+    |
+    | When true, each shop->api() / apiHelper() call checks whether the offline
+    | access token is within the refresh skew window. If so, the cached API
+    | client is discarded and rebuilt with a fresh token. Useful for long-running
+    | queue jobs that reuse the same shop model instance across token expiry.
+    |
+    */
+
+    'refresh_offline_token_before_api_call' => (bool) env('SHOPIFY_REFRESH_OFFLINE_TOKEN_BEFORE_API_CALL', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Shopify API Redirect
     |--------------------------------------------------------------------------
     |

--- a/tests/Actions/MigrateShopToExpiringOfflineAccessTokenTest.php
+++ b/tests/Actions/MigrateShopToExpiringOfflineAccessTokenTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Actions;
+
+use Illuminate\Support\Facades\Crypt;
+use Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class MigrateShopToExpiringOfflineAccessTokenTest extends TestCase
+{
+    public function testMigratesShopWithLegacyOfflineToken(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_legacy_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $result = $this->app->make(MigrateShopToExpiringOfflineAccessToken::class)($shop);
+
+        $this->assertTrue($result['migrated']);
+        $this->assertFalse($result['skipped']);
+        $this->assertNull($result['error']);
+
+        $shop->refresh();
+        $this->assertSame('shpat_expiring_test_token', $shop->getAccessToken()->toNative());
+        $this->assertNotNull($shop->shopify_offline_refresh_token);
+        $this->assertSame(
+            'shprt_expiring_test_refresh',
+            Crypt::decryptString($shop->shopify_offline_refresh_token)
+        );
+    }
+
+    public function testSkipsWhenAlreadyOnExpiringTokens(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_token',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_existing'),
+        ]);
+
+        $result = $this->app->make(MigrateShopToExpiringOfflineAccessToken::class)($shop);
+
+        $this->assertFalse($result['migrated']);
+        $this->assertTrue($result['skipped']);
+        $this->assertSame(MigrateShopToExpiringOfflineAccessToken::REASON_ALREADY_EXPIRING, $result['reason']);
+    }
+
+    public function testSkipsWhenFeatureDisabled(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', false);
+
+        $shop = factory($this->model)->create(['password' => 'shpat_token']);
+
+        $result = $this->app->make(MigrateShopToExpiringOfflineAccessToken::class)($shop);
+
+        $this->assertTrue($result['skipped']);
+        $this->assertSame(MigrateShopToExpiringOfflineAccessToken::REASON_FEATURE_DISABLED, $result['reason']);
+    }
+}

--- a/tests/Console/MigrateExpiringOfflineTokensCommandTest.php
+++ b/tests/Console/MigrateExpiringOfflineTokensCommandTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Console;
+
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Queue;
+use Osiset\ShopifyApp\Messaging\Jobs\MigrateShopTokenJob;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class MigrateExpiringOfflineTokensCommandTest extends TestCase
+{
+    public function testDispatchesJobsForLegacyShopsOnly(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'password' => 'shpat_legacy_one',
+            'shopify_offline_refresh_token' => null,
+        ]);
+        factory($this->model)->create([
+            'password' => 'shpat_legacy_two',
+            'shopify_offline_refresh_token' => null,
+        ]);
+        factory($this->model)->create([
+            'password' => 'shpat_expiring',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_existing'),
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 2 migration job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(MigrateShopTokenJob::class, 2);
+    }
+
+    public function testDryRunDoesNotDispatchJobs(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens --dry-run')
+            ->expectsOutput('Dry run — 1 shop(s) would be migrated.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testFailsWhenFeatureDisabled(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', false);
+
+        factory($this->model)->create([
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('expiring_offline_tokens is disabled. Set SHOPIFY_EXPIRING_OFFLINE_TOKENS=true first.')
+            ->assertExitCode(1);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testShopOptionDispatchesSingleJob(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'name' => 'target.myshopify.com',
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+        factory($this->model)->create([
+            'name' => 'other.myshopify.com',
+            'password' => 'shpat_legacy_other',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens --shop=target.myshopify.com')
+            ->expectsOutput('Dispatched 1 migration job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(MigrateShopTokenJob::class, 1);
+    }
+
+    public function testReportsWhenNoShopsNeedMigration(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('No shops need migration.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+}

--- a/tests/Messaging/Jobs/MigrateShopTokenJobTest.php
+++ b/tests/Messaging/Jobs/MigrateShopTokenJobTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Messaging\Jobs;
+
+use Illuminate\Support\Facades\Crypt;
+use Osiset\ShopifyApp\Messaging\Jobs\MigrateShopTokenJob;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class MigrateShopTokenJobTest extends TestCase
+{
+    public function testMigratesLegacyShopViaTokenExchange(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_legacy_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        MigrateShopTokenJob::dispatchSync($shop);
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_expiring_test_token', $shop->getAccessToken()->toNative());
+        $this->assertNotNull($shop->shopify_offline_refresh_token);
+        $this->assertSame(
+            'shprt_expiring_test_refresh',
+            Crypt::decryptString($shop->shopify_offline_refresh_token)
+        );
+        $this->assertNotNull($shop->shopify_offline_access_token_expires_at);
+        $this->assertNotNull($shop->shopify_offline_refresh_token_expires_at);
+    }
+
+    public function testSkipsAlreadyMigratedShopWithoutError(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_token',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_existing'),
+        ]);
+
+        MigrateShopTokenJob::dispatchSync($shop);
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_token', $shop->getAccessToken()->toNative());
+        $this->assertSame(
+            'shprt_existing',
+            Crypt::decryptString($shop->shopify_offline_refresh_token)
+        );
+    }
+}

--- a/tests/Services/ApiHelperExchangeOfflineTokenTest.php
+++ b/tests/Services/ApiHelperExchangeOfflineTokenTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Services;
+
+use Gnikyt\BasicShopifyAPI\Session;
+use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class ApiHelperExchangeOfflineTokenTest extends TestCase
+{
+    public function testExchangeNonExpiringOfflineTokenForExpiring(): void
+    {
+        $shop = factory($this->model)->create(['password' => 'shpat_legacy']);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $data = $this->app->make(IApiHelper::class)
+            ->exchangeNonExpiringOfflineTokenForExpiring($shop->name, $shop->password);
+
+        $this->assertSame('shpat_expiring_test_token', $data['access_token']);
+        $this->assertSame('shprt_expiring_test_refresh', $data['refresh_token']);
+        $this->assertSame(3600, $data['expires_in']);
+    }
+}

--- a/tests/Services/ApiHelperExchangeOfflineTokenTest.php
+++ b/tests/Services/ApiHelperExchangeOfflineTokenTest.php
@@ -2,7 +2,6 @@
 
 namespace Osiset\ShopifyApp\Test\Services;
 
-use Gnikyt\BasicShopifyAPI\Session;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 use Osiset\ShopifyApp\Test\TestCase;

--- a/tests/Services/LegacyOfflineTokenMigrationTest.php
+++ b/tests/Services/LegacyOfflineTokenMigrationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Services;
+
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Event;
+use Mockery;
+use Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+use Osiset\ShopifyApp\Test\TestCase;
+use RuntimeException;
+
+class LegacyOfflineTokenMigrationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testLazyMigrationRunsBeforeApiHelper(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.auto_migrate_legacy', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_legacy_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $shop->apiHelper();
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_expiring_test_token', $shop->getAccessToken()->toNative());
+        $this->assertNotNull($shop->shopify_offline_refresh_token);
+        $this->assertSame(
+            'shprt_expiring_test_refresh',
+            Crypt::decryptString($shop->shopify_offline_refresh_token)
+        );
+    }
+
+    public function testLazyMigrationSkippedWhenAutoMigrateDisabled(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.auto_migrate_legacy', false);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_legacy_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $shop->apiHelper();
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_legacy_token', $shop->getAccessToken()->toNative());
+        $this->assertNull($shop->shopify_offline_refresh_token);
+    }
+
+    public function testLazyMigrationFailsOpenOnException(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.auto_migrate_legacy', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_legacy_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $mock = Mockery::mock(MigrateShopToExpiringOfflineAccessToken::class);
+        $mock->shouldReceive('__invoke')
+            ->once()
+            ->with($shop)
+            ->andThrow(new RuntimeException('Shopify network error'));
+        $this->app->instance(MigrateShopToExpiringOfflineAccessToken::class, $mock);
+
+        $warnings = [];
+        Event::listen(function (MessageLogged $event) use (&$warnings) {
+            $warnings[] = $event;
+        });
+
+        $this->setApiStub();
+
+        $helper = $shop->apiHelper();
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_legacy_token', $shop->getAccessToken()->toNative());
+        $this->assertNull($shop->shopify_offline_refresh_token);
+        $this->assertNotNull($helper);
+
+        $matching = array_filter($warnings, function (MessageLogged $event) {
+            return $event->level === 'warning'
+                && str_contains($event->message, 'On-the-fly Shopify offline token migration failed.')
+                && ($event->context['message'] ?? '') === 'Shopify network error';
+        });
+        $this->assertCount(1, $matching);
+    }
+}

--- a/tests/Services/OfflineAccessTokenRefresherTest.php
+++ b/tests/Services/OfflineAccessTokenRefresherTest.php
@@ -183,8 +183,10 @@ class OfflineAccessTokenRefresherTest extends TestCase
         app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($shop);
     }
 
-    public function testAccessTokenNeedsRefreshFalseWhenExpiryMissing(): void
+    public function testOfflineAccessTokenNeedsRefreshFalseWhenExpiryMissing(): void
     {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
         $shop = factory($this->model)->create([
             'password' => 'shpat_old',
             'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
@@ -192,10 +194,34 @@ class OfflineAccessTokenRefresherTest extends TestCase
             'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(60),
         ]);
 
-        $refresher = app(OfflineAccessTokenRefresher::class);
-        $method = new \ReflectionMethod(OfflineAccessTokenRefresher::class, 'accessTokenNeedsRefresh');
-        $method->setAccessible(true);
+        $this->assertFalse(app(OfflineAccessTokenRefresher::class)->offlineAccessTokenNeedsRefresh($shop));
+    }
 
-        $this->assertFalse($method->invoke($refresher, $shop));
+    public function testOfflineAccessTokenNeedsRefreshTrueWhenExpired(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subMinutes(5),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(60),
+        ]);
+
+        $this->assertTrue(app(OfflineAccessTokenRefresher::class)->offlineAccessTokenNeedsRefresh($shop));
+    }
+
+    public function testOfflineAccessTokenNeedsRefreshFalseWhenStillFresh(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(60),
+        ]);
+
+        $this->assertFalse(app(OfflineAccessTokenRefresher::class)->offlineAccessTokenNeedsRefresh($shop));
     }
 }

--- a/tests/Traits/ShopModelApiClientRefreshTest.php
+++ b/tests/Traits/ShopModelApiClientRefreshTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Traits;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Crypt;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class ShopModelApiClientRefreshTest extends TestCase
+{
+    protected function configureExpiringTokens(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.auto_migrate_legacy', false);
+    }
+
+    protected function createShopWithExpiringToken(string $password = 'shpat_old'): object
+    {
+        return factory($this->model)->create([
+            'password' => $password,
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(60),
+        ]);
+    }
+
+    public function testOfflineAccessTokenIsFreshReflectsExpiryState(): void
+    {
+        $this->configureExpiringTokens();
+
+        $freshShop = $this->createShopWithExpiringToken();
+        $this->assertTrue($freshShop->offlineAccessTokenIsFresh());
+
+        $expiredShop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subMinutes(5),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(60),
+        ]);
+
+        $this->assertFalse($expiredShop->offlineAccessTokenIsFresh());
+    }
+
+    public function testCachedClientDoesNotRefreshWhenConfigDisabled(): void
+    {
+        $this->configureExpiringTokens();
+        $this->app['config']->set('shopify-app.refresh_offline_token_before_api_call', false);
+
+        $shop = $this->createShopWithExpiringToken();
+        $shop->api();
+
+        Carbon::setTestNow(Carbon::now()->addHours(2));
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh']);
+
+        $shop->api();
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_old', $shop->getAccessToken()->toNative());
+        $this->assertSame(['oauth_offline_refresh'], ApiStub::$stubFiles);
+    }
+
+    public function testCachedClientRefreshesWhenConfigEnabled(): void
+    {
+        $this->configureExpiringTokens();
+        $this->app['config']->set('shopify-app.refresh_offline_token_before_api_call', true);
+
+        $shop = $this->createShopWithExpiringToken();
+        $shop->api();
+
+        Carbon::setTestNow(Carbon::now()->addHours(2));
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh']);
+
+        $shop->api();
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_after_refresh', $shop->getAccessToken()->toNative());
+        $this->assertSame([], ApiStub::$stubFiles);
+    }
+
+    public function testRefreshOfflineAccessTokenIfNeededUpdatesTokenAndClearsCache(): void
+    {
+        $this->configureExpiringTokens();
+
+        $shop = $this->createShopWithExpiringToken();
+        $shop->api();
+        $this->assertNotNull($shop->apiHelper);
+
+        Carbon::setTestNow(Carbon::now()->addHours(2));
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh']);
+
+        $shop->refreshOfflineAccessTokenIfNeeded();
+
+        $this->assertNull($shop->apiHelper);
+        $shop->refresh();
+        $this->assertSame('shpat_after_refresh', $shop->getAccessToken()->toNative());
+
+        $shop->api();
+        $this->assertSame(
+            'shpat_after_refresh',
+            $shop->api()->getSession()->getAccessToken()
+        );
+    }
+
+    public function testResetApiClientForcesRebuildOnNextApiCall(): void
+    {
+        $this->configureExpiringTokens();
+
+        $shop = $this->createShopWithExpiringToken('shpat_first_build');
+        $firstHelper = $shop->apiHelper();
+
+        $shop->resetApiClient();
+
+        $this->assertNull($shop->apiHelper);
+
+        $secondHelper = $shop->apiHelper();
+
+        $this->assertNotSame($firstHelper, $secondHelper);
+    }
+}


### PR DESCRIPTION
## Summary

This PR makes it easy to move existing stores from non-expiring offline tokens to Shopify's expiring offline tokens, and fixes a pain point for queue jobs, where the cached API client keeps using an expired access token, especially for long running jobs!

This is a follow up PR to #471, which adds support for _new_ stores.

---

## Background

Shopify is moving public apps towards expiring offline access tokens (refresh token + rotation). In-fact, within the Dev Dashboard, you've most likely seen this:

<img width="789" height="88" alt="Screenshot 2026-06-09 at 18 55 08" src="https://github.com/user-attachments/assets/acddbc84-3e45-49ac-aab1-690909a1462d" />


Thanks to #471, the package already handles:

- New installs / re-auth
- Automatic refresh when the API client is **first built**

Two gaps remained:

1. **Existing shops** with a legacy token in `password` are not upgraded just by flipping `SHOPIFY_EXPIRING_OFFLINE_TOKENS=true`. Shopify's [Step 4 token exchange](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens) is required.

2. **Long-running jobs** that reuse the same shop model for hours can hit 401s. The API client is memoised on the model and refresh only runs when `$shop->apiHelper` is `null`, so a token that expires mid-job never gets picked up.

---

## Updates in this PR

### 1. Optional migration for legacy shops (Step 4)

**New action:** `MigrateShopToExpiringOfflineAccessToken`
- Exchanges a legacy offline token for an expiring one via Shopify Step 4
- Persists access token, encrypted refresh token, and expiry timestamps
- Idempotent, skips shops that already have a refresh token
- Uses a cache lock to avoid double-migration if a job and lazy migration race

**New API method:** `ApiHelper::exchangeNonExpiringOfflineTokenForExpiring()`
- Low-level Step 4 exchange if you want to wire your own flow

**New Artisan command:** `shopify-app:migrate-expiring-offline-tokens`
- Finds shops with a token in `password` but no `shopify_offline_refresh_token`
- **Does not call Shopify inline**, dispatches `MigrateShopTokenJob` per shop (Vapor/serverless friendly)
- Supports `--dry-run` and `--shop=example.myshopify.com`

**New queue job:** `MigrateShopTokenJob`
- One shop per job; delegates to the action
- Throws on error so the queue can retry

**Passive / lazy migration (default on):**
- Config: `SHOPIFY_AUTO_MIGRATE_LEGACY=true` (default)
- On first `$shop->apiHelper()` / `$shop->api()`, legacy shops are migrated automatically
- **Fail-open**, if migration fails (network, Shopify error), a warning is logged and the request continues with the legacy token

**InstallShop fix:**
- OAuth install no longer goes through `$shop->apiHelper()` before the code exchange, so lazy migration cannot consume API stubs or interfere with re-auth

> **Important:** Step 4 migration is **one-way**, Shopify revokes the old token on success. Use `--dry-run` first in production.

---

### 2. Long-running job token refresh

The API client is cached on the shop model. Previously, refresh only ran when that cache was empty, fine for web requests, not for jobs running for hours or days.

**New config (opt-in, default `false`):**
`SHOPIFY_REFRESH_OFFLINE_TOKEN_BEFORE_API_CALL=true`
- Before each `$shop->api()` / `$shop->apiHelper()` call, checks whether the token is expired or within the refresh skew
- If so, clears the cached client and rebuilds with a fresh token

**New shop helpers:**

| Method | Purpose |
|--------|---------|
| `$shop->offlineAccessTokenIsFresh()` | Returns `true` if the token does not need refreshing yet |
| `$shop->refreshOfflineAccessTokenIfNeeded()` | Refreshes via Shopify and clears the cached client |
| `$shop->resetApiClient()` | Clears the cached client so the next API call rebuilds it |

**Public refresher check:**
`OfflineAccessTokenRefresher::offlineAccessTokenNeedsRefresh($shop)`, shared logic for the helpers and the config-driven path

Default behaviour is **unchanged**, existing apps are unaffected unless they opt in or call the helpers explicitly.

---

### 3. Documentation

- README migration options, long-running job guidance, env vars
- Boost skill `shopify-app-offline-access-tokens`, updated for host apps / AI context

---

## For app developers

### Enable expiring tokens

```env
SHOPIFY_EXPIRING_OFFLINE_TOKENS=true
```

Run package migrations so the shops table has the refresh token columns.

### Migrate existing shops (pick one)

**Passive (default)**, shops migrate on first API use:

```env
SHOPIFY_AUTO_MIGRATE_LEGACY=true
```

**Batch via queue (good for large shop counts!):**

```bash
php artisan shopify-app:migrate-expiring-offline-tokens --dry-run
php artisan shopify-app:migrate-expiring-offline-tokens
# or a single shop:
php artisan shopify-app:migrate-expiring-offline-tokens --shop=example.myshopify.com
```

Ensure a queue worker is running to process `MigrateShopTokenJob`.

**Programmatic:**

```php
$result = app(MigrateShopToExpiringOfflineAccessToken::class)($shop);
// inspect: migrated, skipped, reason, error
```

### Long-running jobs

**Option A, global opt-in:**

```env
SHOPIFY_REFRESH_OFFLINE_TOKEN_BEFORE_API_CALL=true
```

**Option B,  explicit per loop iteration:**

```php
if (! $shop->offlineAccessTokenIsFresh()) {
    $shop->refreshOfflineAccessTokenIfNeeded();
}
$shop->api()->graph('...');
```

**Option C,  manual reset (replaces `$shop->apiHelper = null`):**

```php
$shop->resetApiClient();
$shop->api()->graph('...');
```

---

## New config values

| Env variable | Config key | Default | Purpose |
|---|---|---|---|
| `SHOPIFY_AUTO_MIGRATE_LEGACY` | `auto_migrate_legacy` | `true` | Lazy Step 4 migration on first API use |
| `SHOPIFY_REFRESH_OFFLINE_TOKEN_BEFORE_API_CALL` | `refresh_offline_token_before_api_call` | `false` | Re-check token expiry before each `api()` call |