### PR TITLE
migrate command halts on first shop failure with sync queue driver

### DIFF
--- a/src/Console/MigrateExpiringOfflineTokensCommand.php
+++ b/src/Console/MigrateExpiringOfflineTokensCommand.php
@@ -56,21 +56,27 @@ class MigrateExpiringOfflineTokensCommand extends Command
         }
 
         $dispatched = 0;
+        $failed = 0;
 
-        $query->chunk(100, function ($shops) use (&$dispatched) {
+        $query->chunk(100, function ($shops) use (&$dispatched, &$failed) {
             foreach ($shops as $shop) {
-                MigrateShopTokenJob::dispatch($shop);
-                $dispatched++;
+                try {
+                    MigrateShopTokenJob::dispatch($shop);
+                    $dispatched++;
+                } catch (\Throwable $e) {
+                    $this->warn("  [FAILED] {$shop->name}: {$e->getMessage()}");
+                    $failed++;
+                }
             }
         });
 
-        if ($dispatched === 0) {
+        if ($dispatched === 0 && $failed === 0) {
             $this->info('No shops need migration.');
 
             return self::SUCCESS;
         }
 
-        $this->info("Dispatched {$dispatched} migration job(s).");
+        $this->info("Dispatched {$dispatched} migration job(s).".($failed > 0 ? " {$failed} shop(s) failed and were skipped." : ''));
 
         return self::SUCCESS;
     }

--- a/tests/Console/MigrateExpiringOfflineTokensCommandTest.php
+++ b/tests/Console/MigrateExpiringOfflineTokensCommandTest.php
@@ -5,6 +5,7 @@ namespace Osiset\ShopifyApp\Test\Console;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Queue;
 use Osiset\ShopifyApp\Messaging\Jobs\MigrateShopTokenJob;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
 use Osiset\ShopifyApp\Test\TestCase;
 
 class MigrateExpiringOfflineTokensCommandTest extends TestCase
@@ -111,5 +112,42 @@ class MigrateExpiringOfflineTokensCommandTest extends TestCase
             ->assertExitCode(0);
 
         Queue::assertNothingPushed();
+    }
+
+    /**
+     * Confirms the fix: the command continues processing remaining shops even when one fails,
+     * surfacing a warning for the failing shop and migrating all others.
+     *
+     * This test fails BEFORE the fix and passes once the fix is applied.
+     */
+    public function testCommandContinuesAfterOneShopFails(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('queue.default', 'sync');
+
+        $shopFailing = factory($this->model)->create([
+            'password' => 'shpat_stale_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+        $shopSucceeding = factory($this->model)->create([
+            'password' => 'shpat_valid_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_access_token_invalid_subject_token', 'access_token_expiring']);
+
+        $this->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutputToContain($shopFailing->name)
+            ->expectsOutput('Dispatched 1 migration job(s). 1 shop(s) failed and were skipped.')
+            ->assertExitCode(0);
+
+        // Failing shop: token unchanged
+        $shopFailing->refresh();
+        $this->assertNull($shopFailing->shopify_offline_refresh_token);
+
+        // Succeeding shop: fully migrated
+        $shopSucceeding->refresh();
+        $this->assertNotNull($shopSucceeding->shopify_offline_refresh_token);
     }
 }

--- a/tests/fixtures/oauth_access_token_invalid_subject_token.json
+++ b/tests/fixtures/oauth_access_token_invalid_subject_token.json
@@ -1,0 +1,4 @@
+{
+    "errors": true,
+    "stub_body": "invalid_subject_token"
+}


### PR DESCRIPTION
Resolves #491

When using `QUEUE_CONNECTION=sync`, a single shop failure (e.g. "invalid subject token" from a store that uninstalled the app) throws a `RuntimeException` through `dispatch()`, killing the `foreach` loop and skipping all remaining shops.

This PR changes logic to wrap each `dispatch()` in `try/catch` so failures emit a warning and the loop continues.

- `MigrateExpiringOfflineTokensCommand`: catch per-shop failures, add `$failed` counter and warning output
- `MigrateExpiringOfflineTokensCommandTest`: new test covering the continue-on-failure behaviour
- `fixtures/oauth_access_token_invalid_subject_token.json`: new error fixture