### PR TITLE
redirect to OAuth when refresh token is deleted and access token has expired

### DIFF
--- a/src/Contracts/ShopModel.php
+++ b/src/Contracts/ShopModel.php
@@ -81,6 +81,14 @@ interface ShopModel extends Authenticatable
     public function hasExpiringOfflineAccess(): bool;
 
     /**
+     * Whether the shop is in an unrecoverable corrupt expiring-token state: the refresh token
+     * has been removed but the access token has also expired, making re-authentication required.
+     *
+     * @return bool
+     */
+    public function hasCorruptExpiringTokenState(): bool;
+
+    /**
      * Whether the offline access token is still valid (outside the refresh skew window).
      *
      * @return bool

--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -513,7 +513,7 @@ class VerifyShopify
     {
         $shop = $this->shopQuery->getByDomain(ShopDomain::fromRequest($request), [], true);
 
-        return $shop && $shop->password && ! $shop->trashed();
+        return $shop && $shop->password && ! $shop->trashed() && ! $shop->hasCorruptExpiringTokenState();
     }
 
     /**
@@ -527,7 +527,7 @@ class VerifyShopify
     {
         $shop = $this->shopQuery->getByDomain(ShopDomain::fromRequest($request), [], true);
 
-        return $shop && $shop->password && ! $shop->trashed() ? $shop : null;
+        return $shop && $shop->password && ! $shop->trashed() && ! $shop->hasCorruptExpiringTokenState() ? $shop : null;
     }
 
     /**

--- a/src/Traits/ShopModel.php
+++ b/src/Traits/ShopModel.php
@@ -7,6 +7,7 @@ use Gnikyt\BasicShopifyAPI\Session;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
 use Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
@@ -156,6 +157,20 @@ trait ShopModel
     public function hasExpiringOfflineAccess(): bool
     {
         return ! empty($this->shopify_offline_refresh_token);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCorruptExpiringTokenState(): bool
+    {
+        if (! Util::getShopifyConfig('expiring_offline_tokens', $this)) {
+            return false;
+        }
+
+        return ! empty($this->shopify_offline_access_token_expires_at)
+            && empty($this->shopify_offline_refresh_token)
+            && Carbon::now()->greaterThan($this->shopify_offline_access_token_expires_at);
     }
 
     /**

--- a/tests/Http/Middleware/VerifyShopifyTest.php
+++ b/tests/Http/Middleware/VerifyShopifyTest.php
@@ -3,6 +3,7 @@
 namespace Osiset\ShopifyApp\Test\Http\Middleware;
 
 use Illuminate\Http\Response;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Route;
 use Osiset\ShopifyApp\Exceptions\HttpException;
@@ -350,6 +351,38 @@ class VerifyShopifyTest extends TestCase
         // Run the middleware
         $result = $this->runMiddleware(VerifyShopify::class, $newRequest);
         $this->assertTrue($result[0]);
+    }
+
+    public function testCorruptExpiringTokenStateTriggersInstallRedirect(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        // Shop with corrupt state: password present but refresh token deleted and access token expired
+        factory($this->model)->create([
+            'name' => 'shop-name.myshopify.com',
+            'password' => 'shpat_expired_token',
+            'shopify_offline_refresh_token' => null,
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subHours(2),
+        ]);
+
+        $currentRequest = Request::instance();
+        $newRequest = $currentRequest->duplicate(
+            ['shop' => 'shop-name.myshopify.com'],
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+
+        $result = $this->runMiddleware(VerifyShopify::class, $newRequest);
+
+        // Request must not pass through to the app
+        $this->assertFalse($result[0]);
+
+        // Should redirect to the install/OAuth route, not just to fetch a new App Bridge session token
+        $this->assertStringContainsString('/authenticate', $result[1]->getTargetUrl());
+        $this->assertStringNotContainsString('/authenticate/token', $result[1]->getTargetUrl());
     }
 
     public function testAccessingForbiddenMiddlewareRouteFromBrowserReceivedAccessError(): void

--- a/tests/Traits/ShopModelTest.php
+++ b/tests/Traits/ShopModelTest.php
@@ -3,6 +3,8 @@
 namespace Osiset\ShopifyApp\Test\Traits;
 
 use Gnikyt\BasicShopifyAPI\BasicShopifyAPI;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Crypt;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Objects\Values\AccessToken;
 use Osiset\ShopifyApp\Contracts\Objects\Values\ShopDomain;
@@ -49,6 +51,58 @@ class ShopModelTest extends TestCase
         $shop->save();
         $shop->refresh();
         $this->assertTrue($shop->hasOfflineAccess());
+    }
+
+    public function testHasCorruptExpiringTokenStateWhenRefreshTokenMissingAndAccessTokenExpired(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_some_token',
+            'shopify_offline_refresh_token' => null,
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subHours(2),
+        ]);
+
+        $this->assertTrue($shop->hasCorruptExpiringTokenState());
+    }
+
+    public function testHasCorruptExpiringTokenStateIsFalseWhenAccessTokenStillValid(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_some_token',
+            'shopify_offline_refresh_token' => null,
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+        ]);
+
+        $this->assertFalse($shop->hasCorruptExpiringTokenState());
+    }
+
+    public function testHasCorruptExpiringTokenStateIsFalseWhenRefreshTokenPresent(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_some_token',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_valid_refresh'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subHours(2),
+        ]);
+
+        $this->assertFalse($shop->hasCorruptExpiringTokenState());
+    }
+
+    public function testHasCorruptExpiringTokenStateIsFalseWhenFeatureDisabled(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', false);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_some_token',
+            'shopify_offline_refresh_token' => null,
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subHours(2),
+        ]);
+
+        $this->assertFalse($shop->hasCorruptExpiringTokenState());
     }
 
     public function testNamespacingAndFreemium(): void


### PR DESCRIPTION
Resolves #493

When `shopify_offline_refresh_token` is manually removed from the database and the access token has since expired, the app silently fails. The shop still appears "installed" to the middleware (password is non-empty), so the user remains logged in, but every API call returns 401 and there is no recovery path short of reinstalling.

`VerifyShopify::checkPreviousInstallation()` and `getShopIfAlreadyInstalled()` only check that `password` is non-empty. They have no awareness of expiring-token state. `OfflineAccessTokenRefresher` also bails out early when the refresh token is absent, so the expired access token is never refreshed.

This PR:

- Adds `hasCorruptExpiringTokenState()` to the `ShopModel` trait and contract. Returns `true` when expiring tokens are enabled, the expiry date column is set, the refresh token is missing, and the access token has now expired.
- Both `checkPreviousInstallation()` and `getShopIfAlreadyInstalled()` in `VerifyShopify` now return false for this state, routing the merchant through full OAuth re-authentication.
- If the access token is still within its 1-hour validity window, the state is not flagged,`auto_migrate_legacy` will attempt to re-exchange the token on the next API call as normal.