### PR TITLE
Add proactive refresh command for expiring offline tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For full resources on this package, see the [wiki](../..//wiki).
 [Shopify requires expiring offline access tokens](https://shopify.dev/changelog/expiring-offline-access-tokens-required-for-public-apps-april-1-2026) for **new public apps** created on or after April 1, 2026. This package supports them when enabled:
 
 1. Run package migrations so your shops table includes `shopify_offline_refresh_token`, `shopify_offline_access_token_expires_at`, and `shopify_offline_refresh_token_expires_at`.
-2. Set `SHOPIFY_EXPIRING_OFFLINE_TOKENS=true` in `.env` (see `expiring_offline_tokens`, `auto_migrate_legacy`, and `offline_access_token_refresh_skew_seconds` in `config/shopify-app.php`).
+2. Set `SHOPIFY_EXPIRING_OFFLINE_TOKENS=true` in `.env` (see `expiring_offline_tokens`, `auto_migrate_legacy`, `offline_access_token_refresh_skew_seconds`, and `offline_refresh_token_renewal_days` in `config/shopify-app.php`).
 3. Keep `APP_KEY` stable: refresh tokens are stored encrypted with Laravel’s encrypter.
 
 Authorization code exchange, session-token exchange, and `refresh_token` grants are handled inside this package (`Osiset\ShopifyApp\Services\ApiHelper` and `OfflineAccessTokenRefresher`), not via `gnikyt/basic-shopify-api` updates. A valid access token is refreshed automatically before `apiHelper()` builds the API session when the offline token is expired or within the configured skew.
@@ -67,6 +67,15 @@ Authorization code exchange, session-token exchange, and `refresh_token` grants 
 - **API:** `ApiHelper::exchangeNonExpiringOfflineTokenForExpiring($shopDomain, $currentOfflineToken)` then persist with `ShopCommand::setAccessToken`.
 
 Migration is **one-way**: Shopify revokes the old token on successful exchange.
+
+**Proactive renewal for dormant shops (optional):** Refresh tokens expire after ~90 days. If a shop has no API activity (webhooks, scheduled jobs, etc.) for that long, tokens can lapse. The package provides an opt-in CLI that queues renewal for shops whose refresh token expires within a configurable window (default 14 days via `SHOPIFY_OFFLINE_REFRESH_TOKEN_RENEWAL_DAYS`):
+
+- **Batch CLI:** `php artisan shopify-app:refresh-expiring-offline-tokens` (`--dry-run`, `--shop=example.myshopify.com`, `--days=14`) chunks matching shops and dispatches `RefreshShopOfflineTokenJob` to the queue.
+- **Scheduler (app-owned):** the package does **not** register a schedule automatically. Add to your app's `routes/console.php` or `Kernel`:
+
+```php
+Schedule::command('shopify-app:refresh-expiring-offline-tokens')->daily();
+```
 
 **Long-running jobs:** Token refresh runs when the API client is first built (`$shop->api()` / `$shop->apiHelper()`). If a job reuses the same shop model for hours, the cached client keeps the old access token even after expiry. Options:
 
@@ -113,6 +122,7 @@ Maintainers are users who manage the repository itself, whether it's managing th
 Currently this repository is maintained by:
 
 - [@kyon147](https://github.com/kyon147)
+- [@JonPurvis](https://github.com/JonPurvis)
 - ~[@gnikyt](https://github.com/gnikyt)~ Original author of the package. See [announcement](https://github.com/gnikyt/laravel-shopify/discussions/1276) for details.
 
 Looking to become a maintainer? E-mail @kyon147 directly.

--- a/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
+++ b/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
@@ -13,6 +13,7 @@ You are enabling or operating **Shopify expiring offline access tokens** in **yo
 - `SHOPIFY_AUTO_MIGRATE_LEGACY` → `auto_migrate_legacy` — when `true` (default), legacy shops are migrated on-the-fly before the first `apiHelper()` call; failures fail open (logged warning, legacy token kept).
 - `SHOPIFY_REFRESH_OFFLINE_TOKEN_BEFORE_API_CALL` → `refresh_offline_token_before_api_call` — when `true`, each `api()` / `apiHelper()` call re-checks token expiry and rebuilds the cached client if within the refresh skew (for long-running jobs).
 - `SHOPIFY_OFFLINE_ACCESS_TOKEN_REFRESH_SKEW` → `offline_access_token_refresh_skew_seconds` — refresh this many seconds **before** access token expiry.
+- `SHOPIFY_OFFLINE_REFRESH_TOKEN_RENEWAL_DAYS` → `offline_refresh_token_renewal_days` — shops whose refresh token expires within this many days are queued for renewal by the refresh CLI (default `14`).
 
 Read the package README for policy notes (e.g. public apps after Shopify’s cutoff dates).
 
@@ -44,6 +45,20 @@ Enabling the flag does **not** upgrade shops that only have a legacy non-expirin
 - **`php artisan shopify-app:migrate-expiring-offline-tokens`** — optional CLI (`--dry-run`, `--shop=`). Chunks shops and dispatches queue jobs (Vapor/serverless-safe). Success revokes the old offline token (one-way).
 
 Alternative: merchant re-auth (OAuth or session token exchange) also acquires expiring tokens when the flag is on.
+
+## Proactive renewal for dormant shops (optional)
+
+Refresh tokens expire after ~90 days. Shops with no API activity can lapse if nothing triggers a refresh.
+
+- **`Osiset\ShopifyApp\Messaging\Jobs\RefreshShopOfflineTokenJob`** — dispatched by the refresh Artisan command; one shop per job.
+- **`php artisan shopify-app:refresh-expiring-offline-tokens`** — optional CLI (`--dry-run`, `--shop=`, `--days=`). Queues renewal for shops whose refresh token expires within `offline_refresh_token_renewal_days` (default 14).
+- **Scheduler:** the package does **not** auto-register a schedule. In **your** app:
+
+```php
+Schedule::command('shopify-app:refresh-expiring-offline-tokens')->daily();
+```
+
+Active shops with regular webhooks or API calls are refreshed automatically and usually do not need this.
 
 ## Operational notes
 

--- a/src/Console/RefreshExpiringOfflineTokensCommand.php
+++ b/src/Console/RefreshExpiringOfflineTokensCommand.php
@@ -26,11 +26,20 @@ class RefreshExpiringOfflineTokensCommand extends Command
 
         $modelClass = Util::getShopifyConfig('user_model');
         $shopDomain = $this->option('shop');
-        $days = $this->option('days') !== null
-            ? (int) $this->option('days')
+
+        $daysOption = $this->option('days');
+        $days = $daysOption !== null
+            ? (int) $daysOption
             : (int) Util::getShopifyConfig('offline_refresh_token_renewal_days');
 
-        $threshold = Carbon::now()->addDays($days);
+        if ($days < 0) {
+            $this->error('--days must be 0 or greater.');
+
+            return self::FAILURE;
+        }
+
+        $now = Carbon::now();
+        $threshold = $now->copy()->addDays($days);
 
         $query = $modelClass::query()
             ->whereNotNull('password')
@@ -38,8 +47,7 @@ class RefreshExpiringOfflineTokensCommand extends Command
             ->whereNotNull('shopify_offline_refresh_token')
             ->where('shopify_offline_refresh_token', '!=', '')
             ->whereNotNull('shopify_offline_refresh_token_expires_at')
-            ->where('shopify_offline_refresh_token_expires_at', '<=', $threshold);
-
+            ->whereBetween('shopify_offline_refresh_token_expires_at', [$now, $threshold]);
         if ($shopDomain) {
             $query->where('name', $shopDomain);
         }

--- a/src/Console/RefreshExpiringOfflineTokensCommand.php
+++ b/src/Console/RefreshExpiringOfflineTokensCommand.php
@@ -54,7 +54,7 @@ class RefreshExpiringOfflineTokensCommand extends Command
 
         if ($this->option('dry-run')) {
             $count = 0;
-            $query->chunk(100, function ($shops) use (&$count) {
+            $query->chunkById(100, function ($shops) use (&$count) {
                 foreach ($shops as $shop) {
                     $this->line('  - '.$shop->name.' (id: '.$shop->id.')');
                     $count++;
@@ -73,7 +73,7 @@ class RefreshExpiringOfflineTokensCommand extends Command
         $dispatched = 0;
         $failed = 0;
 
-        $query->chunk(100, function ($shops) use (&$dispatched, &$failed, $days) {
+        $query->chunkById(100, function ($shops) use (&$dispatched, &$failed, $days) {
             foreach ($shops as $shop) {
                 try {
                     RefreshShopOfflineTokenJob::dispatch($shop, $days);

--- a/src/Console/RefreshExpiringOfflineTokensCommand.php
+++ b/src/Console/RefreshExpiringOfflineTokensCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Osiset\ShopifyApp\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Osiset\ShopifyApp\Messaging\Jobs\RefreshShopOfflineTokenJob;
+use Osiset\ShopifyApp\Util;
+
+class RefreshExpiringOfflineTokensCommand extends Command
+{
+    protected $signature = 'shopify-app:refresh-expiring-offline-tokens
+        {--shop= : Renew a single shop by domain (e.g. example.myshopify.com)}
+        {--days= : Override renewal window in days (defaults to config)}
+        {--dry-run : List shops that would be renewed without dispatching jobs}';
+
+    protected $description = 'Dispatch queue jobs to renew expiring offline tokens before the refresh token expires (optional; requires SHOPIFY_EXPIRING_OFFLINE_TOKENS)';
+
+    public function handle(): int
+    {
+        if (! Util::getShopifyConfig('expiring_offline_tokens')) {
+            $this->error('expiring_offline_tokens is disabled. Set SHOPIFY_EXPIRING_OFFLINE_TOKENS=true first.');
+
+            return self::FAILURE;
+        }
+
+        $modelClass = Util::getShopifyConfig('user_model');
+        $shopDomain = $this->option('shop');
+        $days = $this->option('days') !== null
+            ? (int) $this->option('days')
+            : (int) Util::getShopifyConfig('offline_refresh_token_renewal_days');
+
+        $threshold = Carbon::now()->addDays($days);
+
+        $query = $modelClass::query()
+            ->whereNotNull('password')
+            ->where('password', '!=', '')
+            ->whereNotNull('shopify_offline_refresh_token')
+            ->where('shopify_offline_refresh_token', '!=', '')
+            ->whereNotNull('shopify_offline_refresh_token_expires_at')
+            ->where('shopify_offline_refresh_token_expires_at', '<=', $threshold);
+
+        if ($shopDomain) {
+            $query->where('name', $shopDomain);
+        }
+
+        if ($this->option('dry-run')) {
+            $count = 0;
+            $query->chunk(100, function ($shops) use (&$count) {
+                foreach ($shops as $shop) {
+                    $this->line('  - '.$shop->name.' (id: '.$shop->id.')');
+                    $count++;
+                }
+            });
+
+            if ($count === 0) {
+                $this->info('No shops need renewal.');
+            } else {
+                $this->info("Dry run — {$count} shop(s) would be renewed.");
+            }
+
+            return self::SUCCESS;
+        }
+
+        $dispatched = 0;
+        $failed = 0;
+
+        $query->chunk(100, function ($shops) use (&$dispatched, &$failed, $days) {
+            foreach ($shops as $shop) {
+                try {
+                    RefreshShopOfflineTokenJob::dispatch($shop, $days);
+                    $dispatched++;
+                } catch (\Throwable $e) {
+                    $this->warn("  [FAILED] {$shop->name}: {$e->getMessage()}");
+                    $failed++;
+                }
+            }
+        });
+
+        if ($dispatched === 0 && $failed === 0) {
+            $this->info('No shops need renewal.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Dispatched {$dispatched} renewal job(s).".($failed > 0 ? " {$failed} shop(s) failed and were skipped." : ''));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Messaging/Jobs/RefreshShopOfflineTokenJob.php
+++ b/src/Messaging/Jobs/RefreshShopOfflineTokenJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Osiset\ShopifyApp\Messaging\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
+use Osiset\ShopifyApp\Services\OfflineAccessTokenRefresher;
+
+/**
+ * Queue job to renew expiring offline tokens for a single shop.
+ */
+class RefreshShopOfflineTokenJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @param IShopModel $shop
+     * @param int|null   $renewalDays Renewal window in days passed from the Artisan command
+     */
+    public function __construct(protected IShopModel $shop, protected ?int $renewalDays = null)
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(OfflineAccessTokenRefresher $refresher): void
+    {
+        $refresher->refreshIfNeeded($this->shop, $this->renewalDays);
+    }
+}

--- a/src/Services/OfflineAccessTokenRefresher.php
+++ b/src/Services/OfflineAccessTokenRefresher.php
@@ -129,6 +129,9 @@ class OfflineAccessTokenRefresher
     /**
      * Whether the shop's offline refresh token expires within the renewal window.
      *
+     * Already-expired refresh tokens return false because they cannot be renewed
+     * via the refresh-token grant.
+     *
      * @param ShopModel  $shop
      * @param int|null   $renewalDays Override the renewal window in days (defaults to config)
      *
@@ -151,7 +154,14 @@ class OfflineAccessTokenRefresher
 
         $days = $renewalDays ?? (int) Util::getShopifyConfig('offline_refresh_token_renewal_days', $shop);
         $expires = $expiresAt instanceof Carbon ? $expiresAt : Carbon::parse((string) $expiresAt);
-        $threshold = Carbon::now()->addDays($days);
+        $now = Carbon::now();
+
+        // Expired refresh tokens cannot be renewed via the refresh-token grant.
+        if ($expires->lessThanOrEqualTo($now)) {
+            return false;
+        }
+
+        $threshold = $now->copy()->addDays($days);
 
         return $threshold->greaterThanOrEqualTo($expires);
     }

--- a/src/Services/OfflineAccessTokenRefresher.php
+++ b/src/Services/OfflineAccessTokenRefresher.php
@@ -27,13 +27,14 @@ class OfflineAccessTokenRefresher
     /**
      * Refresh the shop's offline access token if it is expired or near expiry.
      *
-     * @param ShopModel $shop
+     * @param ShopModel  $shop
+     * @param int|null   $renewalDays Override the refresh-token renewal window in days (defaults to config)
      *
      * @throws OAuthTokenRefreshException
      *
      * @return void
      */
-    public function refreshIfNeeded(ShopModel $shop): void
+    public function refreshIfNeeded(ShopModel $shop, ?int $renewalDays = null): void
     {
         if (! Util::getShopifyConfig('expiring_offline_tokens', $shop)) {
             return;
@@ -43,14 +44,14 @@ class OfflineAccessTokenRefresher
             return;
         }
 
-        if (! $this->offlineAccessTokenNeedsRefresh($shop)) {
+        if (! $this->offlineTokenNeedsRefresh($shop, $renewalDays)) {
             return;
         }
 
-        Cache::lock('shopify-offline-token:'.$shop->getId()->toNative(), 30)->block(10, function () use ($shop) {
+        Cache::lock('shopify-offline-token:'.$shop->getId()->toNative(), 30)->block(10, function () use ($shop, $renewalDays) {
             $shop->refresh();
 
-            if (! $this->offlineAccessTokenNeedsRefresh($shop)) {
+            if (! $this->offlineTokenNeedsRefresh($shop, $renewalDays)) {
                 return;
             }
 
@@ -123,5 +124,49 @@ class OfflineAccessTokenRefresher
         $threshold = $expires->copy()->subSeconds($skew);
 
         return Carbon::now()->greaterThanOrEqualTo($threshold);
+    }
+
+    /**
+     * Whether the shop's offline refresh token expires within the renewal window.
+     *
+     * @param ShopModel  $shop
+     * @param int|null   $renewalDays Override the renewal window in days (defaults to config)
+     *
+     * @return bool
+     */
+    public function offlineRefreshTokenNeedsRenewal(ShopModel $shop, ?int $renewalDays = null): bool
+    {
+        if (! Util::getShopifyConfig('expiring_offline_tokens', $shop)) {
+            return false;
+        }
+
+        if (! $shop->hasExpiringOfflineAccess()) {
+            return false;
+        }
+
+        $expiresAt = $shop->shopify_offline_refresh_token_expires_at ?? null;
+        if ($expiresAt === null) {
+            return false;
+        }
+
+        $days = $renewalDays ?? (int) Util::getShopifyConfig('offline_refresh_token_renewal_days', $shop);
+        $expires = $expiresAt instanceof Carbon ? $expiresAt : Carbon::parse((string) $expiresAt);
+        $threshold = Carbon::now()->addDays($days);
+
+        return $threshold->greaterThanOrEqualTo($expires);
+    }
+
+    /**
+     * Whether the shop's offline access or refresh token should be renewed.
+     *
+     * @param ShopModel  $shop
+     * @param int|null   $renewalDays Override the refresh-token renewal window in days (defaults to config)
+     *
+     * @return bool
+     */
+    protected function offlineTokenNeedsRefresh(ShopModel $shop, ?int $renewalDays = null): bool
+    {
+        return $this->offlineAccessTokenNeedsRefresh($shop)
+            || $this->offlineRefreshTokenNeedsRenewal($shop, $renewalDays);
     }
 }

--- a/src/ShopifyAppProvider.php
+++ b/src/ShopifyAppProvider.php
@@ -23,6 +23,7 @@ use Osiset\ShopifyApp\Actions\InstallShop as InstallShopAction;
 use Osiset\ShopifyApp\Actions\VerifyThemeSupport as VerifyThemeSupportAction;
 use Osiset\ShopifyApp\Console\AddVariablesCommand;
 use Osiset\ShopifyApp\Console\MigrateExpiringOfflineTokensCommand;
+use Osiset\ShopifyApp\Console\RefreshExpiringOfflineTokensCommand;
 use Osiset\ShopifyApp\Console\WebhookJobMakeCommand;
 use Osiset\ShopifyApp\Contracts\ApiHelper as IApiHelper;
 use Osiset\ShopifyApp\Contracts\Commands\Charge as IChargeCommand;
@@ -91,6 +92,7 @@ class ShopifyAppProvider extends ServiceProvider
         $this->commands([
             AddVariablesCommand::class,
             MigrateExpiringOfflineTokensCommand::class,
+            RefreshExpiringOfflineTokensCommand::class,
             WebhookJobMakeCommand::class,
         ]);
 

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -266,6 +266,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Offline refresh token renewal window (days)
+    |--------------------------------------------------------------------------
+    |
+    | When running shopify-app:refresh-expiring-offline-tokens, shops whose
+    | refresh token expires within this many days are queued for renewal.
+    | Also used by OfflineAccessTokenRefresher to trigger proactive refresh.
+    |
+    */
+
+    'offline_refresh_token_renewal_days' => (int) env('SHOPIFY_OFFLINE_REFRESH_TOKEN_RENEWAL_DAYS', 14),
+
+    /*
+    |--------------------------------------------------------------------------
     | Shopify API Redirect
     |--------------------------------------------------------------------------
     |

--- a/tests/Console/RefreshExpiringOfflineTokensCommandTest.php
+++ b/tests/Console/RefreshExpiringOfflineTokensCommandTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Console;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Queue;
+use Osiset\ShopifyApp\Messaging\Jobs\RefreshShopOfflineTokenJob;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class RefreshExpiringOfflineTokensCommandTest extends TestCase
+{
+    public function testDispatchesJobsForShopsWithinRenewalWindow(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_refresh_token_renewal_days', 14);
+
+        factory($this->model)->create([
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+        factory($this->model)->create([
+            'password' => 'shpat_two',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_two'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(30),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(RefreshShopOfflineTokenJob::class, 1);
+    }
+
+    public function testDryRunDoesNotDispatchJobs(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens --dry-run')
+            ->expectsOutput('Dry run — 1 shop(s) would be renewed.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testFailsWhenFeatureDisabled(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', false);
+
+        factory($this->model)->create([
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('expiring_offline_tokens is disabled. Set SHOPIFY_EXPIRING_OFFLINE_TOKENS=true first.')
+            ->assertExitCode(1);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testShopOptionDispatchesSingleJob(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'name' => 'target.myshopify.com',
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+        factory($this->model)->create([
+            'name' => 'other.myshopify.com',
+            'password' => 'shpat_two',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_two'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens --shop=target.myshopify.com')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(RefreshShopOfflineTokenJob::class, 1);
+    }
+
+    public function testReportsWhenNoShopsNeedRenewal(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('No shops need renewal.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testCommandContinuesAfterOneShopFails(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('queue.default', 'sync');
+
+        $shopFailing = factory($this->model)->create([
+            'password' => 'shpat_failing',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_failing'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subMinutes(5),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+        $shopSucceeding = factory($this->model)->create([
+            'password' => 'shpat_succeeding',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_succeeding'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subMinutes(5),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh_invalid', 'oauth_offline_refresh']);
+
+        $this->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutputToContain($shopFailing->name)
+            ->expectsOutput('Dispatched 1 renewal job(s). 1 shop(s) failed and were skipped.')
+            ->assertExitCode(0);
+
+        $shopFailing->refresh();
+        $this->assertSame('shpat_failing', $shopFailing->getAccessToken()->toNative());
+
+        $shopSucceeding->refresh();
+        $this->assertSame('shpat_after_refresh', $shopSucceeding->getAccessToken()->toNative());
+    }
+
+    public function testDaysOptionIsHonoredInJob(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_refresh_token_renewal_days', 14);
+        $this->app['config']->set('queue.default', 'sync');
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(20),
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh']);
+
+        $this->artisan('shopify-app:refresh-expiring-offline-tokens --days=30')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        $shop->refresh();
+        $this->assertSame('shpat_after_refresh', $shop->getAccessToken()->toNative());
+    }
+}

--- a/tests/Messaging/Jobs/RefreshShopOfflineTokenJobTest.php
+++ b/tests/Messaging/Jobs/RefreshShopOfflineTokenJobTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Osiset\ShopifyApp\Test\Messaging\Jobs;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Crypt;
+use Osiset\ShopifyApp\Messaging\Jobs\RefreshShopOfflineTokenJob;
+use Osiset\ShopifyApp\Test\Stubs\Api as ApiStub;
+use Osiset\ShopifyApp\Test\TestCase;
+
+class RefreshShopOfflineTokenJobTest extends TestCase
+{
+    public function testRenewsShopWithinRefreshTokenWindow(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subMinutes(5),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh']);
+
+        RefreshShopOfflineTokenJob::dispatchSync($shop);
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_after_refresh', $shop->getAccessToken()->toNative());
+        $this->assertSame(
+            'shprt_after_refresh',
+            Crypt::decryptString($shop->shopify_offline_refresh_token)
+        );
+        $this->assertNotNull($shop->shopify_offline_access_token_expires_at);
+        $this->assertNotNull($shop->shopify_offline_refresh_token_expires_at);
+    }
+}

--- a/tests/Services/OfflineAccessTokenRefresherTest.php
+++ b/tests/Services/OfflineAccessTokenRefresherTest.php
@@ -255,6 +255,21 @@ class OfflineAccessTokenRefresherTest extends TestCase
         $this->assertFalse(app(OfflineAccessTokenRefresher::class)->offlineRefreshTokenNeedsRenewal($shop));
     }
 
+    public function testOfflineRefreshTokenNeedsRenewalFalseWhenAlreadyExpired(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_refresh_token_renewal_days', 14);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->subDay(),
+        ]);
+
+        $this->assertFalse(app(OfflineAccessTokenRefresher::class)->offlineRefreshTokenNeedsRenewal($shop));
+    }
+
     public function testOfflineRefreshTokenNeedsRenewalFalseWhenFeatureDisabled(): void
     {
         $this->app['config']->set('shopify-app.expiring_offline_tokens', false);

--- a/tests/Services/OfflineAccessTokenRefresherTest.php
+++ b/tests/Services/OfflineAccessTokenRefresherTest.php
@@ -224,4 +224,91 @@ class OfflineAccessTokenRefresherTest extends TestCase
 
         $this->assertFalse(app(OfflineAccessTokenRefresher::class)->offlineAccessTokenNeedsRefresh($shop));
     }
+
+    public function testOfflineRefreshTokenNeedsRenewalTrueWhenWithinWindow(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_refresh_token_renewal_days', 14);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this->assertTrue(app(OfflineAccessTokenRefresher::class)->offlineRefreshTokenNeedsRenewal($shop));
+    }
+
+    public function testOfflineRefreshTokenNeedsRenewalFalseWhenOutsideWindow(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_refresh_token_renewal_days', 14);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(30),
+        ]);
+
+        $this->assertFalse(app(OfflineAccessTokenRefresher::class)->offlineRefreshTokenNeedsRenewal($shop));
+    }
+
+    public function testOfflineRefreshTokenNeedsRenewalFalseWhenFeatureDisabled(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', false);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this->assertFalse(app(OfflineAccessTokenRefresher::class)->offlineRefreshTokenNeedsRenewal($shop));
+    }
+
+    public function testRefreshIfNeededWhenOnlyRefreshTokenWithinWindow(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_refresh_token_renewal_days', 14);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh']);
+
+        app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($shop);
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_after_refresh', $shop->getAccessToken()->toNative());
+        $this->assertSame(
+            'shprt_after_refresh',
+            Crypt::decryptString($shop->shopify_offline_refresh_token)
+        );
+    }
+
+    public function testOfflineRefreshTokenNeedsRenewalHonorsRenewalDaysOverride(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_refresh_token_renewal_days', 14);
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->addHour(),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(20),
+        ]);
+
+        $refresher = app(OfflineAccessTokenRefresher::class);
+
+        $this->assertFalse($refresher->offlineRefreshTokenNeedsRenewal($shop));
+        $this->assertTrue($refresher->offlineRefreshTokenNeedsRenewal($shop, 30));
+    }
 }


### PR DESCRIPTION
Adds an opt-in Artisan command to renew expiring offline tokens for dormant shops before the ~90-day refresh token expires. The package provides the command and job; apps register it in their own scheduler.

Personally, a couple of my apps I'd expect a merchant to set up, and then not really need to visit the admin again!

Changes / updates in this PR:

- `shopify-app:refresh-expiring-offline-tokens` with `--dry-run`, `--shop=`, and `--days=` (defaults to config)
- `RefreshShopOfflineTokenJob`: one shop per job, passes renewal window to refresher
- `OfflineAccessTokenRefresher`/`offlineRefreshTokenNeedsRenewal()`; refresh when access token is due or refresh token is within the window
- `SHOPIFY_OFFLINE_REFRESH_TOKEN_RENEWAL_DAYS`: default `14`
- Docs in README and offline-access-tokens skill (I'll update the wiki once merged)

You can either run it manually:

```
    php artisan shopify-app:refresh-expiring-offline-tokens --dry-run
    php artisan shopify-app:refresh-expiring-offline-tokens
```

Or, schedule in your app (this package does not register this automatically):

```
Schedule::command('shopify-app:refresh-expiring-offline-tokens')->daily();
```