### PR TITLE
Escape redirect URLs in OAuth and billing views

### DIFF
--- a/src/Traits/AuthController.php
+++ b/src/Traits/AuthController.php
@@ -92,34 +92,47 @@ trait AuthController
     {
         $request->session()->reflash();
         $shopDomain = ShopDomain::fromRequest($request);
-        $target = $request->query('target');
+
+        $target = Util::sanitizeTokenRedirectTarget(
+            $request->query('target'),
+            $request->getSchemeAndHttpHost()
+        );
+
+        $fallbackPath = parse_url(route(Util::getShopifyConfig('route_names.home'), [], false), PHP_URL_PATH) ?: '/';
+
+        return View::make(
+            'shopify-app::auth.token',
+            [
+                'shopDomain' => $shopDomain->toNative(),
+                'target' => $this->buildCleanTokenTarget($request, $shopDomain, $target),
+                'fallbackTarget' => $this->buildCleanTokenTarget($request, $shopDomain, $fallbackPath),
+            ]
+        );
+    }
+
+    /**
+     * Build a token redirect target with shop, host, and locale query params.
+     */
+    protected function buildCleanTokenTarget(Request $request, ShopDomain $shopDomain, string $target): string
+    {
         $query = parse_url($target, PHP_URL_QUERY);
 
-        $cleanTarget = $target;
         if ($query) {
-            // remove "token" from the target's query string
             $params = Util::parseQueryString($query);
             $params['shop'] = $params['shop'] ?? $shopDomain->toNative() ?? '';
             $params['host'] = $request->get('host');
             $params['locale'] = $request->get('locale');
             unset($params['token']);
 
-            $cleanTarget = trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
-        } else {
-            $params = [
-                'shop' => $shopDomain->toNative() ?? '',
-                'host' => $request->get('host'),
-                'locale' => $request->get('locale'),
-            ];
-            $cleanTarget = trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
+            return trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
         }
 
-        return View::make(
-            'shopify-app::auth.token',
-            [
-                'shopDomain' => $shopDomain->toNative(),
-                'target' => $cleanTarget,
-            ]
-        );
+        $params = [
+            'shop' => $shopDomain->toNative() ?? '',
+            'host' => $request->get('host'),
+            'locale' => $request->get('locale'),
+        ];
+
+        return trim(explode('?', $target)[0].'?'.http_build_query($params), '?');
     }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -254,4 +254,62 @@ class Util
 
         return (bool) Arr::get($legacySupports, $feature, true);
     }
+
+    /**
+     * Constrain a token-redirect target to a same-origin relative path.
+     *
+     * @param string|null $target        The requested redirect target.
+     * @param string      $requestOrigin The current request origin (scheme + host + port).
+     *
+     * @return string A safe relative path (optionally with query string).
+     */
+    public static function sanitizeTokenRedirectTarget(?string $target, string $requestOrigin): string
+    {
+        if ($target === null || $target === '') {
+            return '/';
+        }
+
+        if (str_starts_with($target, '//')) {
+            return '/';
+        }
+
+        if (preg_match('#^(javascript|data|vbscript):#i', $target)) {
+            return '/';
+        }
+
+        if (str_starts_with($target, '/') && ! str_starts_with($target, '//')) {
+            return $target;
+        }
+
+        $parsed = parse_url($target);
+        if (! isset($parsed['scheme'], $parsed['host'])) {
+            return '/';
+        }
+
+        if (! in_array(strtolower($parsed['scheme']), ['http', 'https'], true)) {
+            return '/';
+        }
+
+        $requestParsed = parse_url($requestOrigin);
+        $targetHost = strtolower($parsed['host']);
+        $requestHost = strtolower($requestParsed['host'] ?? '');
+
+        $targetPort = $parsed['port'] ?? (strtolower($parsed['scheme']) === 'https' ? 443 : 80);
+        $requestPort = $requestParsed['port'] ?? (strtolower($requestParsed['scheme'] ?? 'http') === 'https' ? 443 : 80);
+
+        if ($targetHost !== $requestHost || $targetPort !== $requestPort) {
+            return '/';
+        }
+
+        $path = $parsed['path'] ?? '/';
+        if (! str_starts_with($path, '/')) {
+            $path = '/'.$path;
+        }
+
+        if (! empty($parsed['query'])) {
+            return $path.'?'.$parsed['query'];
+        }
+
+        return $path;
+    }
 }

--- a/src/resources/views/auth/fullpage_redirect.blade.php
+++ b/src/resources/views/auth/fullpage_redirect.blade.php
@@ -12,7 +12,7 @@
 
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function () {
-                let redirectUrl = "{!! $url !!}";
+                let redirectUrl = @json($url);
 
                 if (window.top === window.self) {
                     window.top.location.href = redirectUrl;

--- a/src/resources/views/auth/token.blade.php
+++ b/src/resources/views/auth/token.blade.php
@@ -48,7 +48,7 @@
 
                 shopify.idToken().then((token) => {
 
-                    let url = new URL(`{!! $target !!}`, window.location.origin);
+                    let url = new URL(@json($target), window.location.origin);
                     // Enforce HTTPS if the current page is using HTTPS
                     if (window.location.protocol === 'https:') {
                         url.protocol = 'https:';

--- a/src/resources/views/auth/token.blade.php
+++ b/src/resources/views/auth/token.blade.php
@@ -49,6 +49,11 @@
                 shopify.idToken().then((token) => {
 
                     let url = new URL(@json($target), window.location.origin);
+
+                    if (url.origin !== window.location.origin) {
+                        url = new URL(@json($fallbackTarget), window.location.origin);
+                    }
+
                     // Enforce HTTPS if the current page is using HTTPS
                     if (window.location.protocol === 'https:') {
                         url.protocol = 'https:';

--- a/src/resources/views/billing/fullpage_redirect.blade.php
+++ b/src/resources/views/billing/fullpage_redirect.blade.php
@@ -10,7 +10,7 @@
 
         <script type="text/javascript">
             document.addEventListener('DOMContentLoaded', function () {
-                let redirectUrl = "{!! $url !!}";
+                let redirectUrl = @json($url);
 
                 if (window.top === window.self) {
                     window.top.location.href = redirectUrl;

--- a/tests/Traits/AuthControllerTest.php
+++ b/tests/Traits/AuthControllerTest.php
@@ -79,4 +79,34 @@ class AuthControllerTest extends TestCase
         // Call authenticate with no parameters
         $this->call('get', '/authenticate');
     }
+
+    public function testTokenRejectsExternalTarget(): void
+    {
+        $response = $this->call('get', '/authenticate/token', [
+            'shop' => 'example.myshopify.com',
+            'target' => 'https://evil.com',
+            'host' => 'ZXhhbXBsZS5teXNob3BpZnkuY29t',
+        ]);
+
+        $response->assertViewHas('target', function (string $target): bool {
+            return ! str_contains($target, 'evil.com');
+        });
+
+        $response->assertViewHas('target', function (string $target): bool {
+            return str_starts_with($target, '/?shop=example.myshopify.com');
+        });
+    }
+
+    public function testTokenAcceptsRelativeTarget(): void
+    {
+        $response = $this->call('get', '/authenticate/token', [
+            'shop' => 'example.myshopify.com',
+            'target' => '/orders',
+            'host' => 'ZXhhbXBsZS5teXNob3BpZnkuY29t',
+        ]);
+
+        $response->assertViewHas('target', function (string $target): bool {
+            return str_starts_with($target, '/orders?shop=example.myshopify.com');
+        });
+    }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -134,4 +134,27 @@ class UtilTest extends TestCase
             );
         }
     }
+
+    /**
+     * @dataProvider sanitizeTokenRedirectTargetProvider
+     */
+    public function testSanitizeTokenRedirectTarget(?string $target, string $origin, string $expected): void
+    {
+        $this->assertSame($expected, Util::sanitizeTokenRedirectTarget($target, $origin));
+    }
+
+    public static function sanitizeTokenRedirectTargetProvider(): array
+    {
+        return [
+            'null target' => [null, 'http://localhost', '/'],
+            'empty target' => ['', 'http://localhost', '/'],
+            'relative path' => ['/orders', 'http://localhost', '/orders'],
+            'protocol relative' => ['//evil.com', 'http://localhost', '/'],
+            'javascript scheme' => ['javascript:alert(1)', 'http://localhost', '/'],
+            'external https' => ['https://evil.com', 'http://localhost', '/'],
+            'same origin absolute' => ['http://localhost/orders', 'http://localhost', '/orders'],
+            'same origin absolute with query' => ['http://localhost/orders?foo=bar', 'http://localhost', '/orders?foo=bar'],
+            'port mismatch' => ['http://localhost:8080/foo', 'http://localhost', '/'],
+        ];
+    }
 }


### PR DESCRIPTION
Fixes latent XSS / open-redirect sinks in redirect views where URLs were embedded in JavaScript via unescaped Blade output (`{!! $url !!}`) by using `@json($url)` instead.

Closes #496

Apps that published views with `vendor:publish` keep their own copies and must republish or update manually.