### PR TITLE
Throw an exception if the API route is opened in a browser.

### DIFF
--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -116,6 +116,10 @@ class VerifyShopify
         $tokenSource = $this->getAccessTokenFromRequest($request);
 
         if ($tokenSource === null) {
+            if (!Util::isMPAApplication() && str_contains($request->path(), 'api/')) {
+                throw new HttpException('Access denied.', Response::HTTP_FORBIDDEN);
+            }
+
             $forbiddenMiddlewareMatches = array_intersect(
                 Util::getShopifyConfig('forbidden_web_middleware_groups'),
                 $request->route()?->middleware() ?? []

--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -116,8 +116,8 @@ class VerifyShopify
         $tokenSource = $this->getAccessTokenFromRequest($request);
 
         if ($tokenSource === null) {
-            if (!Util::isMPAApplication() && str_contains($request->path(), 'api/')) {
-                throw new HttpException('Access denied.', Response::HTTP_FORBIDDEN);
+            if (!Util::isMPAApplication() && $this->isApiRequest($request)) {
+                throw new HttpException(SessionToken::EXCEPTION_INVALID, Response::HTTP_BAD_REQUEST);
             }
 
             $forbiddenMiddlewareMatches = array_intersect(
@@ -495,7 +495,7 @@ class VerifyShopify
     }
 
     /**
-     * Determine if the request is AJAX or expects JSON.
+     * Determine if the request is an API request.
      *
      * @param Request $request The request object.
      *
@@ -503,7 +503,7 @@ class VerifyShopify
      */
     protected function isApiRequest(Request $request): bool
     {
-        return $request->ajax() || $request->expectsJson();
+        return $request->ajax() || $request->expectsJson() || $request->bearerToken() !== null;
     }
 
     /**

--- a/src/Http/Middleware/VerifyShopify.php
+++ b/src/Http/Middleware/VerifyShopify.php
@@ -494,6 +494,30 @@ class VerifyShopify
         return $formatValue($value);
     }
 
+    protected function isApiRoutePath(string $path): bool
+    {
+        $prefixes = Util::getShopifyConfig('api_route_prefixes');
+
+        if (empty($prefixes)) {
+            return false;
+        }
+
+        $path = ltrim($path, '/');
+
+        foreach ($prefixes as $prefix) {
+            $prefix = trim($prefix, '/');
+            if ($prefix === '') {
+                continue;
+            }
+
+            if ($path === $prefix || Str::startsWith($path, $prefix.'/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Determine if the request is an API request.
      *
@@ -503,7 +527,7 @@ class VerifyShopify
      */
     protected function isApiRequest(Request $request): bool
     {
-        return $request->ajax() || $request->expectsJson() || $request->bearerToken() !== null;
+        return $request->ajax() || $request->expectsJson() || $this->isApiRoutePath($request->path());
     }
 
     /**

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -654,5 +654,19 @@ return [
     */
     'forbidden_web_middleware_groups' => [
         'api',
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | API route prefixes
+    |--------------------------------------------------------------------------
+    |
+    | Path prefixes that identify API routes. A request whose path starts with
+    | one of these is treated as an API request even when it carries no bearer
+    | token and no AJAX/JSON headers (e.g. a browser opening the route directly).
+    |
+    */
+    'api_route_prefixes' => [
+        'api',
+    ],
 ];

--- a/tests/Http/Middleware/VerifyShopifyTest.php
+++ b/tests/Http/Middleware/VerifyShopifyTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Route;
 use Osiset\ShopifyApp\Exceptions\HttpException;
 use Osiset\ShopifyApp\Exceptions\SignatureVerificationException;
 use Osiset\ShopifyApp\Http\Middleware\VerifyShopify;
+use Osiset\ShopifyApp\Objects\Values\SessionToken;
 use Osiset\ShopifyApp\Test\TestCase;
 
 class VerifyShopifyTest extends TestCase
@@ -385,11 +386,11 @@ class VerifyShopifyTest extends TestCase
         $this->assertStringNotContainsString('/authenticate/token', $result[1]->getTargetUrl());
     }
 
-    public function testSpaApiRequestWithoutTokenReceivesAccessDenied(): void
+    public function testSpaApiRequestWithoutTokenReceivesInvalidTokenError(): void
     {
         $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('Access denied.');
-        $this->expectExceptionCode(Response::HTTP_FORBIDDEN);
+        $this->expectExceptionMessage(SessionToken::EXCEPTION_INVALID);
+        $this->expectExceptionCode(Response::HTTP_BAD_REQUEST);
 
         factory($this->model)->create(['name' => 'shop-name.myshopify.com']);
         $this->app['config']->set('shopify-app.frontend_type', 'SPA');

--- a/tests/Http/Middleware/VerifyShopifyTest.php
+++ b/tests/Http/Middleware/VerifyShopifyTest.php
@@ -385,6 +385,28 @@ class VerifyShopifyTest extends TestCase
         $this->assertStringNotContainsString('/authenticate/token', $result[1]->getTargetUrl());
     }
 
+    public function testSpaApiRequestWithoutTokenReceivesAccessDenied(): void
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Access denied.');
+        $this->expectExceptionCode(Response::HTTP_FORBIDDEN);
+
+        factory($this->model)->create(['name' => 'shop-name.myshopify.com']);
+        $this->app['config']->set('shopify-app.frontend_type', 'SPA');
+
+        $currentRequest = Request::instance();
+        $newRequest = $currentRequest->duplicate(
+            query: [],
+            server: [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+                'HTTP_X-Shop-Domain' => 'shop-name.myshopify.com',
+                'REQUEST_URI' => 'api/some/endpoint',
+            ]
+        );
+
+        $this->runMiddleware(VerifyShopify::class, $newRequest);
+    }
+
     public function testAccessingForbiddenMiddlewareRouteFromBrowserReceivedAccessError(): void
     {
         $this->expectException(HttpException::class);

--- a/tests/Http/Middleware/VerifyShopifyTest.php
+++ b/tests/Http/Middleware/VerifyShopifyTest.php
@@ -399,7 +399,6 @@ class VerifyShopifyTest extends TestCase
         $newRequest = $currentRequest->duplicate(
             query: [],
             server: [
-                'HTTP_X-Requested-With' => 'XMLHttpRequest',
                 'HTTP_X-Shop-Domain' => 'shop-name.myshopify.com',
                 'REQUEST_URI' => 'api/some/endpoint',
             ]
@@ -420,14 +419,12 @@ class VerifyShopifyTest extends TestCase
         $this->app['config']->set('shopify-app.forbidden_web_middleware_groups', ['api']);
         $this->app['router']->get('/api/some/endpoint', fn () => true)->middleware(['api']);
 
-        // Setup the request
         $currentRequest = Request::instance();
         $newRequest = $currentRequest->duplicate(
             query: [
                 'shop' => 'shop-name.myshopify.com',
             ],
             server: [
-                'HTTP_Authorization' => "Bearer {$this->buildToken()}",
                 'REQUEST_URI' => 'api/some/endpoint',
             ]
         );


### PR DESCRIPTION
isApiRequest() determines whether a request is an API request based on the X-Requested-With and Accept headers, which are set by the client, not the server. As a result, a request to an api/ endpoint that lacks these headers (curl, a third-party HTTP client) is treated by the middleware as a "browser" request: instead of an error, it receives a 302 redirect to the token-retrieval route, and before that an unnecessary database query (checkPreviousInstallation) is executed.

for API endpoints, the classification should be based on the path (api/ in the URL), not on headers. A request to such a path without an authorization token should be rejected immediately with a 403, without hitting the database and without redirects.