### PR TITLE
Add queue and connection targeting for offline token batch commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Authorization code exchange, session-token exchange, and `refresh_token` grants 
 **Migrating existing installs (optional):** Shops that already have a non-expiring offline token are not upgraded automatically when you enable the flag alone. Options:
 
 - **Passive (default):** With `SHOPIFY_AUTO_MIGRATE_LEGACY=true` (default), the first `apiHelper()` call for a legacy shop runs Shopify [Step 4](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens) token exchange synchronously. Failures are logged and the request continues with the legacy token (fail-open).
-- **Batch CLI (serverless-safe):** `php artisan shopify-app:migrate-expiring-offline-tokens` (`--dry-run`, `--shop=example.myshopify.com`) chunks matching shops and dispatches `MigrateShopTokenJob` to the queue — no HTTP in the command itself (suitable for Laravel Vapor).
+- **Batch CLI (serverless-safe):** `php artisan shopify-app:migrate-expiring-offline-tokens` (`--dry-run`, `--shop=example.myshopify.com`, `--queue=`, `--connection=`) chunks matching shops and dispatches `MigrateShopTokenJob` to the queue — no HTTP in the command itself (suitable for Laravel Vapor). Without `--queue=` / config, jobs use the app default queue. Set `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_CONNECTION` (or matching `job_queues` / `job_connections` keys) for a dedicated worker.
 - **Action:** `MigrateShopToExpiringOfflineAccessToken` — call per shop from your own code; returns `migrated`, `skipped`, `reason`, and `error` keys.
 - **API:** `ApiHelper::exchangeNonExpiringOfflineTokenForExpiring($shopDomain, $currentOfflineToken)` then persist with `ShopCommand::setAccessToken`.
 
@@ -70,7 +70,7 @@ Migration is **one-way**: Shopify revokes the old token on successful exchange.
 
 **Proactive renewal for dormant shops (optional):** Refresh tokens expire after ~90 days. If a shop has no API activity (webhooks, scheduled jobs, etc.) for that long, tokens can lapse. The package provides an opt-in CLI that queues renewal for shops whose refresh token expires within a configurable window (default 14 days via `SHOPIFY_OFFLINE_REFRESH_TOKEN_RENEWAL_DAYS`):
 
-- **Batch CLI:** `php artisan shopify-app:refresh-expiring-offline-tokens` (`--dry-run`, `--shop=example.myshopify.com`, `--days=14`) chunks matching shops and dispatches `RefreshShopOfflineTokenJob` to the queue.
+- **Batch CLI:** `php artisan shopify-app:refresh-expiring-offline-tokens` (`--dry-run`, `--shop=example.myshopify.com`, `--days=14`, `--queue=`, `--connection=`) chunks matching shops and dispatches `RefreshShopOfflineTokenJob` to the queue. Use `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_CONNECTION` (or CLI overrides) to target a dedicated worker; otherwise jobs use the app default queue.
 - **Scheduler (app-owned):** the package does **not** register a schedule automatically. Add to your app's `routes/console.php` or `Kernel`:
 
 ```php

--- a/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
+++ b/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
@@ -14,6 +14,8 @@ You are enabling or operating **Shopify expiring offline access tokens** in **yo
 - `SHOPIFY_REFRESH_OFFLINE_TOKEN_BEFORE_API_CALL` → `refresh_offline_token_before_api_call` — when `true`, each `api()` / `apiHelper()` call re-checks token expiry and rebuilds the cached client if within the refresh skew (for long-running jobs).
 - `SHOPIFY_OFFLINE_ACCESS_TOKEN_REFRESH_SKEW` → `offline_access_token_refresh_skew_seconds` — refresh this many seconds **before** access token expiry.
 - `SHOPIFY_OFFLINE_REFRESH_TOKEN_RENEWAL_DAYS` → `offline_refresh_token_renewal_days` — shops whose refresh token expires within this many days are queued for renewal by the refresh CLI (default `14`).
+- `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_CONNECTION` → `job_queues.migrate_expiring_offline_tokens` / `job_connections.migrate_expiring_offline_tokens` — queue targeting for the migrate Artisan command (overridable with `--queue=` / `--connection=`).
+- `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_CONNECTION` → `job_queues.refresh_expiring_offline_tokens` / `job_connections.refresh_expiring_offline_tokens` — same for the refresh Artisan command.
 
 Read the package README for policy notes (e.g. public apps after Shopify’s cutoff dates).
 
@@ -42,7 +44,7 @@ Enabling the flag does **not** upgrade shops that only have a legacy non-expirin
 - **`Osiset\ShopifyApp\Messaging\Jobs\MigrateShopTokenJob`** — dispatched by the Artisan command or your own scheduler; one shop per job.
 - **`Osiset\ShopifyApp\Actions\MigrateShopToExpiringOfflineAccessToken`** — invoke per shop from your code; inspect `migrated`, `skipped`, `reason`, `error` in the returned array.
 - **`ApiHelper::exchangeNonExpiringOfflineTokenForExpiring($shopDomain, $currentToken)`** — [Shopify Step 4](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens#step-4-migrate-existing-tokens) token exchange; then persist via `ShopCommand::setAccessToken` with refresh + expiry fields.
-- **`php artisan shopify-app:migrate-expiring-offline-tokens`** — optional CLI (`--dry-run`, `--shop=`). Chunks shops and dispatches queue jobs (Vapor/serverless-safe). Success revokes the old offline token (one-way).
+- **`php artisan shopify-app:migrate-expiring-offline-tokens`** — optional CLI (`--dry-run`, `--shop=`, `--queue=`, `--connection=`). Chunks shops and dispatches queue jobs (Vapor/serverless-safe). Defaults to the app queue; set `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_CONNECTION` or use CLI overrides for a dedicated worker. Success revokes the old offline token (one-way).
 
 Alternative: merchant re-auth (OAuth or session token exchange) also acquires expiring tokens when the flag is on.
 
@@ -51,7 +53,7 @@ Alternative: merchant re-auth (OAuth or session token exchange) also acquires ex
 Refresh tokens expire after ~90 days. Shops with no API activity can lapse if nothing triggers a refresh.
 
 - **`Osiset\ShopifyApp\Messaging\Jobs\RefreshShopOfflineTokenJob`** — dispatched by the refresh Artisan command; one shop per job.
-- **`php artisan shopify-app:refresh-expiring-offline-tokens`** — optional CLI (`--dry-run`, `--shop=`, `--days=`). Queues renewal for shops whose refresh token expires within `offline_refresh_token_renewal_days` (default 14).
+- **`php artisan shopify-app:refresh-expiring-offline-tokens`** — optional CLI (`--dry-run`, `--shop=`, `--days=`, `--queue=`, `--connection=`). Queues renewal for shops whose refresh token expires within `offline_refresh_token_renewal_days` (default 14). Defaults to the app queue; set `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_CONNECTION` or use CLI overrides for a dedicated worker.
 - **Scheduler:** the package does **not** auto-register a schedule. In **your** app:
 
 ```php

--- a/src/Console/MigrateExpiringOfflineTokensCommand.php
+++ b/src/Console/MigrateExpiringOfflineTokensCommand.php
@@ -3,6 +3,7 @@
 namespace Osiset\ShopifyApp\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Bus\PendingDispatch;
 use Osiset\ShopifyApp\Messaging\Jobs\MigrateShopTokenJob;
 use Osiset\ShopifyApp\Util;
 
@@ -10,7 +11,9 @@ class MigrateExpiringOfflineTokensCommand extends Command
 {
     protected $signature = 'shopify-app:migrate-expiring-offline-tokens
         {--shop= : Migrate a single shop by domain (e.g. example.myshopify.com)}
-        {--dry-run : List shops that would be migrated without dispatching jobs}';
+        {--dry-run : List shops that would be migrated without dispatching jobs}
+        {--queue= : Queue name for dispatched jobs (overrides config)}
+        {--connection= : Queue connection for dispatched jobs (overrides config)}';
 
     protected $description = 'Dispatch queue jobs to migrate legacy non-expiring offline tokens to expiring offline tokens (optional; requires SHOPIFY_EXPIRING_OFFLINE_TOKENS)';
 
@@ -39,7 +42,7 @@ class MigrateExpiringOfflineTokensCommand extends Command
 
         if ($this->option('dry-run')) {
             $count = 0;
-            $query->chunk(100, function ($shops) use (&$count) {
+            $query->chunkById(100, function ($shops) use (&$count) {
                 foreach ($shops as $shop) {
                     $this->line('  - '.$shop->name.' (id: '.$shop->id.')');
                     $count++;
@@ -58,10 +61,10 @@ class MigrateExpiringOfflineTokensCommand extends Command
         $dispatched = 0;
         $failed = 0;
 
-        $query->chunk(100, function ($shops) use (&$dispatched, &$failed) {
+        $query->chunkById(100, function ($shops) use (&$dispatched, &$failed) {
             foreach ($shops as $shop) {
                 try {
-                    MigrateShopTokenJob::dispatch($shop);
+                    $this->configureJobDispatch(MigrateShopTokenJob::dispatch($shop));
                     $dispatched++;
                 } catch (\Throwable $e) {
                     $this->warn("  [FAILED] {$shop->name}: {$e->getMessage()}");
@@ -79,5 +82,26 @@ class MigrateExpiringOfflineTokensCommand extends Command
         $this->info("Dispatched {$dispatched} migration job(s).".($failed > 0 ? " {$failed} shop(s) failed and were skipped." : ''));
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Apply queue/connection from CLI options or config to a pending dispatch.
+     */
+    protected function configureJobDispatch(PendingDispatch $dispatch): PendingDispatch
+    {
+        $connection = $this->option('connection')
+            ?: (Util::getShopifyConfig('job_connections')['migrate_expiring_offline_tokens'] ?? null);
+        $queue = $this->option('queue')
+            ?: (Util::getShopifyConfig('job_queues')['migrate_expiring_offline_tokens'] ?? null);
+
+        if ($connection) {
+            $dispatch->onConnection($connection);
+        }
+
+        if ($queue) {
+            $dispatch->onQueue($queue);
+        }
+
+        return $dispatch;
     }
 }

--- a/src/Console/RefreshExpiringOfflineTokensCommand.php
+++ b/src/Console/RefreshExpiringOfflineTokensCommand.php
@@ -3,6 +3,7 @@
 namespace Osiset\ShopifyApp\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Carbon;
 use Osiset\ShopifyApp\Messaging\Jobs\RefreshShopOfflineTokenJob;
 use Osiset\ShopifyApp\Util;
@@ -12,7 +13,9 @@ class RefreshExpiringOfflineTokensCommand extends Command
     protected $signature = 'shopify-app:refresh-expiring-offline-tokens
         {--shop= : Renew a single shop by domain (e.g. example.myshopify.com)}
         {--days= : Override renewal window in days (defaults to config)}
-        {--dry-run : List shops that would be renewed without dispatching jobs}';
+        {--dry-run : List shops that would be renewed without dispatching jobs}
+        {--queue= : Queue name for dispatched jobs (overrides config)}
+        {--connection= : Queue connection for dispatched jobs (overrides config)}';
 
     protected $description = 'Dispatch queue jobs to renew expiring offline tokens before the refresh token expires (optional; requires SHOPIFY_EXPIRING_OFFLINE_TOKENS)';
 
@@ -76,7 +79,7 @@ class RefreshExpiringOfflineTokensCommand extends Command
         $query->chunkById(100, function ($shops) use (&$dispatched, &$failed, $days) {
             foreach ($shops as $shop) {
                 try {
-                    RefreshShopOfflineTokenJob::dispatch($shop, $days);
+                    $this->configureJobDispatch(RefreshShopOfflineTokenJob::dispatch($shop, $days));
                     $dispatched++;
                 } catch (\Throwable $e) {
                     $this->warn("  [FAILED] {$shop->name}: {$e->getMessage()}");
@@ -94,5 +97,26 @@ class RefreshExpiringOfflineTokensCommand extends Command
         $this->info("Dispatched {$dispatched} renewal job(s).".($failed > 0 ? " {$failed} shop(s) failed and were skipped." : ''));
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Apply queue/connection from CLI options or config to a pending dispatch.
+     */
+    protected function configureJobDispatch(PendingDispatch $dispatch): PendingDispatch
+    {
+        $connection = $this->option('connection')
+            ?: (Util::getShopifyConfig('job_connections')['refresh_expiring_offline_tokens'] ?? null);
+        $queue = $this->option('queue')
+            ?: (Util::getShopifyConfig('job_queues')['refresh_expiring_offline_tokens'] ?? null);
+
+        if ($connection) {
+            $dispatch->onConnection($connection);
+        }
+
+        if ($queue) {
+            $dispatch->onQueue($queue);
+        }
+
+        return $dispatch;
     }
 }

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -519,8 +519,9 @@ return [
     | Job Queues
     |--------------------------------------------------------------------------
     |
-    | This option is for setting a specific job queue for webhooks, scripttags
-    | and after_authenticate_job.
+    | This option is for setting a specific job queue for webhooks, scripttags,
+    | after_authenticate_job, and offline-token migrate/refresh batch jobs.
+    | Override per run with --queue= on the migrate/refresh Artisan commands.
     |
     */
 
@@ -528,14 +529,17 @@ return [
         'webhooks' => env('WEBHOOKS_JOB_QUEUE', null),
         'scripttags' => env('SCRIPTTAGS_JOB_QUEUE', null),
         'after_authenticate' => env('AFTER_AUTHENTICATE_JOB_QUEUE', null),
+        'migrate_expiring_offline_tokens' => env('SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_QUEUE', null),
+        'refresh_expiring_offline_tokens' => env('SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_QUEUE', null),
     ],
     /*
     |--------------------------------------------------------------------------
     | Job Connections
     |--------------------------------------------------------------------------
     |
-    | This option is for setting a specific job connection for webhooks, scripttags
-    | and after_authenticate_job.
+    | This option is for setting a specific job connection for webhooks, scripttags,
+    | after_authenticate_job, and offline-token migrate/refresh batch jobs.
+    | Override per run with --connection= on the migrate/refresh Artisan commands.
     |
     */
 
@@ -543,6 +547,8 @@ return [
         'webhooks' => env('WEBHOOKS_JOB_CONNECTION', null),
         'scripttags' => env('SCRIPTTAGS_JOB_CONNECTION', null),
         'after_authenticate' => env('AFTER_AUTHENTICATE_JOB_CONNECTION', null),
+        'migrate_expiring_offline_tokens' => env('SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_CONNECTION', null),
+        'refresh_expiring_offline_tokens' => env('SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_CONNECTION', null),
     ],
     /*
     |--------------------------------------------------------------------------

--- a/tests/Console/MigrateExpiringOfflineTokensCommandTest.php
+++ b/tests/Console/MigrateExpiringOfflineTokensCommandTest.php
@@ -150,4 +150,97 @@ class MigrateExpiringOfflineTokensCommandTest extends TestCase
         $shopSucceeding->refresh();
         $this->assertNotNull($shopSucceeding->shopify_offline_refresh_token);
     }
+
+    public function testDispatchesJobsToConfiguredQueue(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.job_queues', [
+            'migrate_expiring_offline_tokens' => 'shopify-tokens',
+        ]);
+
+        factory($this->model)->create([
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 migration job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(MigrateShopTokenJob::class, function ($job) {
+            return $job->queue === 'shopify-tokens';
+        });
+    }
+
+    public function testDispatchesJobsToConfiguredConnection(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.job_connections', [
+            'migrate_expiring_offline_tokens' => 'custom_connection',
+        ]);
+
+        factory($this->model)->create([
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 migration job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(MigrateShopTokenJob::class, function ($job) {
+            return $job->connection === 'custom_connection';
+        });
+    }
+
+    public function testQueueOptionOverridesConfiguredQueue(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.job_queues', [
+            'migrate_expiring_offline_tokens' => 'from-config',
+        ]);
+
+        factory($this->model)->create([
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens --queue=from-cli')
+            ->expectsOutput('Dispatched 1 migration job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(MigrateShopTokenJob::class, function ($job) {
+            return $job->queue === 'from-cli';
+        });
+    }
+
+    public function testDispatchesJobsWithoutQueueOrConnectionByDefault(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 migration job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(MigrateShopTokenJob::class, function ($job) {
+            return $job->queue === null && $job->connection === null;
+        });
+    }
 }

--- a/tests/Console/RefreshExpiringOfflineTokensCommandTest.php
+++ b/tests/Console/RefreshExpiringOfflineTokensCommandTest.php
@@ -174,4 +174,101 @@ class RefreshExpiringOfflineTokensCommandTest extends TestCase
         $shop->refresh();
         $this->assertSame('shpat_after_refresh', $shop->getAccessToken()->toNative());
     }
+
+    public function testDispatchesJobsToConfiguredQueue(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.job_queues', [
+            'refresh_expiring_offline_tokens' => 'shopify-tokens',
+        ]);
+
+        factory($this->model)->create([
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(RefreshShopOfflineTokenJob::class, function ($job) {
+            return $job->queue === 'shopify-tokens';
+        });
+    }
+
+    public function testDispatchesJobsToConfiguredConnection(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.job_connections', [
+            'refresh_expiring_offline_tokens' => 'custom_connection',
+        ]);
+
+        factory($this->model)->create([
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(RefreshShopOfflineTokenJob::class, function ($job) {
+            return $job->connection === 'custom_connection';
+        });
+    }
+
+    public function testQueueOptionOverridesConfiguredQueue(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.job_queues', [
+            'refresh_expiring_offline_tokens' => 'from-config',
+        ]);
+
+        factory($this->model)->create([
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens --queue=from-cli')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(RefreshShopOfflineTokenJob::class, function ($job) {
+            return $job->queue === 'from-cli';
+        });
+    }
+
+    public function testDispatchesJobsWithoutQueueOrConnectionByDefault(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(RefreshShopOfflineTokenJob::class, function ($job) {
+            return $job->queue === null && $job->connection === null;
+        });
+    }
 }


### PR DESCRIPTION

## Summary

- Add configurable queue/connection targeting for `MigrateShopTokenJob` and `RefreshShopOfflineTokenJob`, matching the existing `job_queues` / `job_connections` pattern used by webhooks and script tags
- Add `--queue=` and `--connection=` options to both offline-token Artisan commands (CLI overrides config)
- Switch `migrate-expiring-offline-tokens` from `chunk()` to `chunkById()` for safer iteration when jobs run on the sync driver

Previously, `shopify-app:migrate-expiring-offline-tokens` and `shopify-app:refresh-expiring-offline-tokens` dispatched jobs to the app default queue with no way to target a dedicated worker.

## Configuration

New `job_queues` / `job_connections` keys:

- `migrate_expiring_offline_tokens` - `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_CONNECTION`
- `refresh_expiring_offline_tokens` - `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_CONNECTION`

Resolution order: CLI option > config > default queue (unchanged behaviour when unset).

## Usage

```bash
# One-off override
php artisan shopify-app:migrate-expiring-offline-tokens --queue=shopify-tokens
php artisan shopify-app:refresh-expiring-offline-tokens --queue=shopify-tokens --connection=redis

# Or via .env
SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_QUEUE=shopify-tokens
SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_QUEUE=shopify-tokens