### PR TITLE
Fixing issue with WebhookJobMakeCommand with laravel v13.25.0

### DIFF
--- a/src/Console/WebhookJobMakeCommand.php
+++ b/src/Console/WebhookJobMakeCommand.php
@@ -10,11 +10,13 @@ use Symfony\Component\Console\Input\InputArgument;
 class WebhookJobMakeCommand extends JobMakeCommand
 {
     /**
-     * The console command name.
+     * The console command signature.
      *
      * @var string
      */
-    protected $name = 'shopify-app:make:webhook';
+    protected $signature = 'shopify-app:make:webhook
+        {name : The name of the class}
+        {topic : The event/topic for the job (orders/create, products/update, etc)}';
 
     /**
      * The console command description.


### PR DESCRIPTION
New laravel version v13.25.0 added changes to Illuminate\Foundation\Console\JobMakeCommand file which started presenting issues with the WebhookJobMakeCommand, which laravel stopped identifying the command name