### PR TITLE
Add exclusion logic for offline access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,16 @@ For full resources on this package, see the [wiki](../..//wiki).
 [Shopify requires expiring offline access tokens](https://shopify.dev/changelog/expiring-offline-access-tokens-required-for-public-apps-april-1-2026) for **new public apps** created on or after April 1, 2026. This package supports them when enabled:
 
 1. Run package migrations so your shops table includes `shopify_offline_refresh_token`, `shopify_offline_access_token_expires_at`, and `shopify_offline_refresh_token_expires_at`.
-2. Set `SHOPIFY_EXPIRING_OFFLINE_TOKENS=true` in `.env` (see `expiring_offline_tokens`, `auto_migrate_legacy`, `offline_access_token_refresh_skew_seconds`, and `offline_refresh_token_renewal_days` in `config/shopify-app.php`).
+2. Set `SHOPIFY_EXPIRING_OFFLINE_TOKENS=true` in `.env` (see `expiring_offline_tokens`, `auto_migrate_legacy`, `offline_access_token_refresh_skew_seconds`, `offline_refresh_token_renewal_days`, and `offline_token_excluded_shops` in `config/shopify-app.php`).
 3. Keep `APP_KEY` stable: refresh tokens are stored encrypted with Laravel’s encrypter.
+
+Shops with an empty `password` are skipped for cycle and refresh (the merchant must re-authenticate). `SHOPIFY_AUTO_MIGRATE_LEGACY` stays `true` by default so real legacy shops still migrate on the first `apiHelper()` call; empty-password and denylisted shops are never cycled. To skip placeholder or non-Shopify domains:
+
+```
+SHOPIFY_OFFLINE_TOKEN_EXCLUDED_SHOPS=placeholder.myshopify.com,monitoring.myshopify.com
+```
+
+`$shop->api()` / `$shop->apiHelper()` still build a client for those shops; they are not migrated or refreshed. This is not an auth or uninstall bypass. Apps that already published `config/shopify-app.php` must add `offline_token_excluded_shops` to pick up the env var.
 
 Authorization code exchange, session-token exchange, and `refresh_token` grants are handled inside this package (`Osiset\ShopifyApp\Services\ApiHelper` and `OfflineAccessTokenRefresher`), not via `gnikyt/basic-shopify-api` updates. A valid access token is refreshed automatically before `apiHelper()` builds the API session when the offline token is expired or within the configured skew.
 

--- a/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
+++ b/resources/boost/skills/shopify-app-offline-access-tokens/SKILL.md
@@ -16,6 +16,9 @@ You are enabling or operating **Shopify expiring offline access tokens** in **yo
 - `SHOPIFY_OFFLINE_REFRESH_TOKEN_RENEWAL_DAYS` → `offline_refresh_token_renewal_days` — shops whose refresh token expires within this many days are queued for renewal by the refresh CLI (default `14`).
 - `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_MIGRATE_OFFLINE_TOKENS_JOB_CONNECTION` → `job_queues.migrate_expiring_offline_tokens` / `job_connections.migrate_expiring_offline_tokens` — queue targeting for the migrate Artisan command (overridable with `--queue=` / `--connection=`).
 - `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_QUEUE` / `SHOPIFY_REFRESH_OFFLINE_TOKENS_JOB_CONNECTION` → `job_queues.refresh_expiring_offline_tokens` / `job_connections.refresh_expiring_offline_tokens` — same for the refresh Artisan command.
+- `SHOPIFY_OFFLINE_TOKEN_EXCLUDED_SHOPS` → `offline_token_excluded_shops` — comma-separated shop domains skipped for cycle and refresh (not an auth bypass). Default empty. `--shop=` does not override. `$shop->apiHelper()` still builds a client.
+
+Shops with an empty `password` are also skipped for cycle and refresh (merchant must re-authenticate). `auto_migrate_legacy` remains `true` by default; denylisted and empty-password shops are still not cycled.
 
 Read the package README for policy notes (e.g. public apps after Shopify’s cutoff dates).
 

--- a/src/Actions/MigrateShopToExpiringOfflineAccessToken.php
+++ b/src/Actions/MigrateShopToExpiringOfflineAccessToken.php
@@ -28,6 +28,8 @@ class MigrateShopToExpiringOfflineAccessToken
 
     public const REASON_SHOP_NOT_FOUND = 'shop_not_found';
 
+    public const REASON_EXCLUDED = 'excluded';
+
     public function __construct(
         protected IShopQuery $shopQuery,
         protected IShopCommand $shopCommand,
@@ -52,6 +54,10 @@ class MigrateShopToExpiringOfflineAccessToken
 
         if (! Util::getShopifyConfig('expiring_offline_tokens', $shop)) {
             return $this->result(skipped: true, reason: self::REASON_FEATURE_DISABLED, shopId: $shop->getId()->toNative());
+        }
+
+        if (Util::shopIsExcludedFromOfflineTokenLifecycle($shop)) {
+            return $this->result(skipped: true, reason: self::REASON_EXCLUDED, shopId: $shop->getId()->toNative());
         }
 
         if ($shop->hasExpiringOfflineAccess()) {

--- a/src/Console/MigrateExpiringOfflineTokensCommand.php
+++ b/src/Console/MigrateExpiringOfflineTokensCommand.php
@@ -40,10 +40,18 @@ class MigrateExpiringOfflineTokensCommand extends Command
             $query->where('name', $shopDomain);
         }
 
+        $excluded = Util::getOfflineTokenExcludedShopDomains();
+        if ($excluded !== []) {
+            $query->whereNotIn('name', $excluded);
+        }
+
         if ($this->option('dry-run')) {
             $count = 0;
             $query->chunkById(100, function ($shops) use (&$count) {
                 foreach ($shops as $shop) {
+                    if (Util::shopIsExcludedFromOfflineTokenLifecycle($shop)) {
+                        continue;
+                    }
                     $this->line('  - '.$shop->name.' (id: '.$shop->id.')');
                     $count++;
                 }
@@ -63,6 +71,10 @@ class MigrateExpiringOfflineTokensCommand extends Command
 
         $query->chunkById(100, function ($shops) use (&$dispatched, &$failed) {
             foreach ($shops as $shop) {
+                if (Util::shopIsExcludedFromOfflineTokenLifecycle($shop)) {
+                    continue;
+                }
+
                 try {
                     $this->configureJobDispatch(MigrateShopTokenJob::dispatch($shop));
                     $dispatched++;

--- a/src/Console/RefreshExpiringOfflineTokensCommand.php
+++ b/src/Console/RefreshExpiringOfflineTokensCommand.php
@@ -55,10 +55,18 @@ class RefreshExpiringOfflineTokensCommand extends Command
             $query->where('name', $shopDomain);
         }
 
+        $excluded = Util::getOfflineTokenExcludedShopDomains();
+        if ($excluded !== []) {
+            $query->whereNotIn('name', $excluded);
+        }
+
         if ($this->option('dry-run')) {
             $count = 0;
             $query->chunkById(100, function ($shops) use (&$count) {
                 foreach ($shops as $shop) {
+                    if (Util::shopIsExcludedFromOfflineTokenLifecycle($shop)) {
+                        continue;
+                    }
                     $this->line('  - '.$shop->name.' (id: '.$shop->id.')');
                     $count++;
                 }
@@ -78,6 +86,10 @@ class RefreshExpiringOfflineTokensCommand extends Command
 
         $query->chunkById(100, function ($shops) use (&$dispatched, &$failed, $days) {
             foreach ($shops as $shop) {
+                if (Util::shopIsExcludedFromOfflineTokenLifecycle($shop)) {
+                    continue;
+                }
+
                 try {
                     $this->configureJobDispatch(RefreshShopOfflineTokenJob::dispatch($shop, $days));
                     $dispatched++;

--- a/src/Services/OfflineAccessTokenRefresher.php
+++ b/src/Services/OfflineAccessTokenRefresher.php
@@ -40,6 +40,14 @@ class OfflineAccessTokenRefresher
             return;
         }
 
+        if (! $shop->hasOfflineAccess()) {
+            return;
+        }
+
+        if (Util::shopIsExcludedFromOfflineTokenLifecycle($shop)) {
+            return;
+        }
+
         if (! $shop->hasExpiringOfflineAccess()) {
             return;
         }

--- a/src/Traits/ShopModel.php
+++ b/src/Traits/ShopModel.php
@@ -260,10 +260,13 @@ trait ShopModel
      */
     protected function buildApiHelper(): void
     {
-        if (Util::getShopifyConfig('auto_migrate_legacy', $this)
+        $skipLifecycle = ! $this->hasOfflineAccess()
+            || Util::shopIsExcludedFromOfflineTokenLifecycle($this);
+
+        if (! $skipLifecycle
+            && Util::getShopifyConfig('auto_migrate_legacy', $this)
             && Util::getShopifyConfig('expiring_offline_tokens', $this)
             && ! $this->hasExpiringOfflineAccess()
-            && $this->hasOfflineAccess()
         ) {
             try {
                 app(MigrateShopToExpiringOfflineAccessToken::class)($this);
@@ -276,7 +279,9 @@ trait ShopModel
             }
         }
 
-        app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($this);
+        if (! $skipLifecycle) {
+            app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($this);
+        }
 
         $session = new Session(
             $this->getDomain()->toNative(),

--- a/src/Util.php
+++ b/src/Util.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use LogicException;
+use Osiset\ShopifyApp\Contracts\ShopModel as IShopModel;
 use Osiset\ShopifyApp\Objects\Enums\FrontendType;
 use Osiset\ShopifyApp\Objects\Values\Hmac;
 
@@ -196,6 +197,52 @@ class Util
         }
 
         return Arr::get($config, $key);
+    }
+
+    /**
+     * Shop domains excluded from offline-token cycle and refresh.
+     *
+     * @return array<int, string>
+     */
+    public static function getOfflineTokenExcludedShopDomains(): array
+    {
+        $raw = self::getShopifyConfig('offline_token_excluded_shops') ?? [];
+
+        if (is_string($raw)) {
+            $raw = explode(',', $raw);
+        }
+
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        $domains = [];
+        foreach ($raw as $domain) {
+            $normalized = strtolower(trim((string) $domain));
+            if ($normalized === '') {
+                continue;
+            }
+
+            $domains[$normalized] = $normalized;
+        }
+
+        return array_values($domains);
+    }
+
+    /**
+     * Whether this shop should skip offline-token cycle and refresh.
+     *
+     * Does not block building an API client.
+     *
+     * @param IShopModel $shop
+     *
+     * @return bool
+     */
+    public static function shopIsExcludedFromOfflineTokenLifecycle(IShopModel $shop): bool
+    {
+        $domain = strtolower($shop->getDomain()->toNative());
+
+        return in_array($domain, self::getOfflineTokenExcludedShopDomains(), true);
     }
 
     /**

--- a/src/resources/config/shopify-app.php
+++ b/src/resources/config/shopify-app.php
@@ -235,6 +235,9 @@ return [
     | request continues with the legacy token. Disable to require explicit
     | migration via the Artisan command or MigrateShopToExpiringOfflineAccessToken.
     |
+    | Default stays true so real legacy shops "just work". Denylisted shops and
+    | shops with an empty password are never cycled, even when this is true.
+    |
     */
 
     'auto_migrate_legacy' => (bool) env('SHOPIFY_AUTO_MIGRATE_LEGACY', true),
@@ -276,6 +279,24 @@ return [
     */
 
     'offline_refresh_token_renewal_days' => (int) env('SHOPIFY_OFFLINE_REFRESH_TOKEN_RENEWAL_DAYS', 14),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Offline token excluded shops
+    |--------------------------------------------------------------------------
+    |
+    | Shop domains (name / *.myshopify.com) skipped for offline-token cycle
+    | and refresh (Artisan commands, auto-migrate, and refreshIfNeeded).
+    | Does not block api() / apiHelper() from building a client, and is not
+    | an auth or uninstall bypass. Apps with a published config copy must
+    | add this key to pick up the env var.
+    |
+    */
+
+    'offline_token_excluded_shops' => array_values(array_filter(array_map(
+        static fn (string $domain): string => strtolower(trim($domain)),
+        explode(',', (string) env('SHOPIFY_OFFLINE_TOKEN_EXCLUDED_SHOPS', ''))
+    ))),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Actions/MigrateShopToExpiringOfflineAccessTokenTest.php
+++ b/tests/Actions/MigrateShopToExpiringOfflineAccessTokenTest.php
@@ -63,4 +63,54 @@ class MigrateShopToExpiringOfflineAccessTokenTest extends TestCase
         $this->assertTrue($result['skipped']);
         $this->assertSame(MigrateShopToExpiringOfflineAccessToken::REASON_FEATURE_DISABLED, $result['reason']);
     }
+
+    public function testSkipsWhenPasswordEmpty(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => '',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $result = $this->app->make(MigrateShopToExpiringOfflineAccessToken::class)($shop);
+
+        $this->assertFalse($result['migrated']);
+        $this->assertTrue($result['skipped']);
+        $this->assertSame(MigrateShopToExpiringOfflineAccessToken::REASON_NO_OFFLINE_TOKEN, $result['reason']);
+
+        $shop->refresh();
+        $this->assertSame('', $shop->password);
+        $this->assertNull($shop->shopify_offline_refresh_token);
+    }
+
+    public function testSkipsWhenShopIsExcluded(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        $shop = factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_legacy_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $result = $this->app->make(MigrateShopToExpiringOfflineAccessToken::class)($shop);
+
+        $this->assertFalse($result['migrated']);
+        $this->assertTrue($result['skipped']);
+        $this->assertSame(MigrateShopToExpiringOfflineAccessToken::REASON_EXCLUDED, $result['reason']);
+
+        $shop->refresh();
+        $this->assertSame('shpat_legacy_token', $shop->getAccessToken()->toNative());
+        $this->assertNull($shop->shopify_offline_refresh_token);
+    }
 }

--- a/tests/Console/MigrateExpiringOfflineTokensCommandTest.php
+++ b/tests/Console/MigrateExpiringOfflineTokensCommandTest.php
@@ -100,6 +100,134 @@ class MigrateExpiringOfflineTokensCommandTest extends TestCase
         Queue::assertPushed(MigrateShopTokenJob::class, 1);
     }
 
+    public function testSkipsShopsWithEmptyPassword(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'name' => 'empty-password.myshopify.com',
+            'password' => '',
+            'shopify_offline_refresh_token' => null,
+        ]);
+        factory($this->model)->create([
+            'name' => 'legacy.myshopify.com',
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 migration job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(MigrateShopTokenJob::class, 1);
+    }
+
+    public function testSkipsExcludedShops(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_placeholder',
+            'shopify_offline_refresh_token' => null,
+        ]);
+        factory($this->model)->create([
+            'name' => 'legacy.myshopify.com',
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 migration job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(MigrateShopTokenJob::class, 1);
+    }
+
+    public function testShopOptionDoesNotOverrideExclusion(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_placeholder',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens --shop=placeholder.myshopify.com')
+            ->expectsOutput('No shops need migration.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testDryRunOmitsExcludedShops(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_placeholder',
+            'shopify_offline_refresh_token' => null,
+        ]);
+        factory($this->model)->create([
+            'name' => 'legacy.myshopify.com',
+            'password' => 'shpat_legacy',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens --dry-run')
+            ->expectsOutputToContain('legacy.myshopify.com')
+            ->expectsOutput('Dry run — 1 shop(s) would be migrated.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testSkipsExcludedShopsWhenNameCaseDiffers(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        factory($this->model)->create([
+            'name' => 'Placeholder.myshopify.com',
+            'password' => 'shpat_placeholder',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this
+            ->artisan('shopify-app:migrate-expiring-offline-tokens')
+            ->expectsOutput('No shops need migration.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
     public function testReportsWhenNoShopsNeedMigration(): void
     {
         Queue::fake();

--- a/tests/Console/RefreshExpiringOfflineTokensCommandTest.php
+++ b/tests/Console/RefreshExpiringOfflineTokensCommandTest.php
@@ -104,6 +104,142 @@ class RefreshExpiringOfflineTokensCommandTest extends TestCase
         Queue::assertPushed(RefreshShopOfflineTokenJob::class, 1);
     }
 
+    public function testSkipsShopsWithEmptyPassword(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        factory($this->model)->create([
+            'name' => 'empty-password.myshopify.com',
+            'password' => '',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_leftover'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+        factory($this->model)->create([
+            'name' => 'renew.myshopify.com',
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(RefreshShopOfflineTokenJob::class, 1);
+    }
+
+    public function testSkipsExcludedShops(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_placeholder',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_placeholder'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+        factory($this->model)->create([
+            'name' => 'renew.myshopify.com',
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('Dispatched 1 renewal job(s).')
+            ->assertExitCode(0);
+
+        Queue::assertPushed(RefreshShopOfflineTokenJob::class, 1);
+    }
+
+    public function testShopOptionDoesNotOverrideExclusion(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_placeholder',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_placeholder'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens --shop=placeholder.myshopify.com')
+            ->expectsOutput('No shops need renewal.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testDryRunOmitsExcludedShops(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_placeholder',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_placeholder'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+        factory($this->model)->create([
+            'name' => 'renew.myshopify.com',
+            'password' => 'shpat_one',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_one'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens --dry-run')
+            ->expectsOutputToContain('renew.myshopify.com')
+            ->expectsOutput('Dry run — 1 shop(s) would be renewed.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function testSkipsExcludedShopsWhenNameCaseDiffers(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        factory($this->model)->create([
+            'name' => 'Placeholder.myshopify.com',
+            'password' => 'shpat_placeholder',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_placeholder'),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this
+            ->artisan('shopify-app:refresh-expiring-offline-tokens')
+            ->expectsOutput('No shops need renewal.')
+            ->assertExitCode(0);
+
+        Queue::assertNothingPushed();
+    }
+
     public function testReportsWhenNoShopsNeedRenewal(): void
     {
         Queue::fake();

--- a/tests/Services/LegacyOfflineTokenMigrationTest.php
+++ b/tests/Services/LegacyOfflineTokenMigrationTest.php
@@ -104,4 +104,74 @@ class LegacyOfflineTokenMigrationTest extends TestCase
         });
         $this->assertCount(1, $matching);
     }
+
+    public function testLazyMigrationSkippedWhenPasswordEmpty(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.auto_migrate_legacy', true);
+
+        $shop = factory($this->model)->create([
+            'password' => '',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $helper = $shop->apiHelper();
+
+        $shop->refresh();
+
+        $this->assertSame('', $shop->password);
+        $this->assertNull($shop->shopify_offline_refresh_token);
+        $this->assertNotNull($helper);
+    }
+
+    public function testLazyMigrationSkippedWhenShopIsExcluded(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.auto_migrate_legacy', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        $shop = factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_legacy_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $helper = $shop->apiHelper();
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_legacy_token', $shop->getAccessToken()->toNative());
+        $this->assertNull($shop->shopify_offline_refresh_token);
+        $this->assertNotNull($helper);
+    }
+
+    public function testLazyMigrationRunsWhenAutoMigrateLeftAtDefault(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $this->assertTrue((bool) $this->app['config']->get('shopify-app.auto_migrate_legacy'));
+
+        $shop = factory($this->model)->create([
+            'password' => 'shpat_legacy_token',
+            'shopify_offline_refresh_token' => null,
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['access_token_expiring']);
+
+        $shop->apiHelper();
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_expiring_test_token', $shop->getAccessToken()->toNative());
+        $this->assertNotNull($shop->shopify_offline_refresh_token);
+    }
 }

--- a/tests/Services/OfflineAccessTokenRefresherTest.php
+++ b/tests/Services/OfflineAccessTokenRefresherTest.php
@@ -326,4 +326,64 @@ class OfflineAccessTokenRefresherTest extends TestCase
         $this->assertFalse($refresher->offlineRefreshTokenNeedsRenewal($shop));
         $this->assertTrue($refresher->offlineRefreshTokenNeedsRenewal($shop, 30));
     }
+
+    public function testDoesNotRefreshWhenPasswordEmpty(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => '',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subMinutes(5),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh']);
+
+        app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($shop);
+
+        $helper = $shop->apiHelper();
+
+        $shop->refresh();
+
+        $this->assertSame('', $shop->password);
+        $this->assertSame(
+            'shprt_old',
+            Crypt::decryptString($shop->shopify_offline_refresh_token)
+        );
+        $this->assertNotNull($helper);
+    }
+
+    public function testDoesNotRefreshWhenShopIsExcluded(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        $shop = factory($this->model)->create([
+            'name' => 'placeholder.myshopify.com',
+            'password' => 'shpat_old',
+            'shopify_offline_refresh_token' => Crypt::encryptString('shprt_old'),
+            'shopify_offline_access_token_expires_at' => Carbon::now()->subMinutes(5),
+            'shopify_offline_refresh_token_expires_at' => Carbon::now()->addDays(7),
+        ]);
+
+        $this->setApiStub();
+        ApiStub::stubResponses(['oauth_offline_refresh']);
+
+        app(OfflineAccessTokenRefresher::class)->refreshIfNeeded($shop);
+
+        $helper = $shop->apiHelper();
+
+        $shop->refresh();
+
+        $this->assertSame('shpat_old', $shop->getAccessToken()->toNative());
+        $this->assertSame(
+            'shprt_old',
+            Crypt::decryptString($shop->shopify_offline_refresh_token)
+        );
+        $this->assertNotNull($helper);
+    }
 }

--- a/tests/Traits/ShopModelTest.php
+++ b/tests/Traits/ShopModelTest.php
@@ -105,6 +105,19 @@ class ShopModelTest extends TestCase
         $this->assertFalse($shop->hasCorruptExpiringTokenState());
     }
 
+    public function testHasCorruptExpiringTokenStateIsFalseWhenPasswordEmpty(): void
+    {
+        $this->app['config']->set('shopify-app.expiring_offline_tokens', true);
+
+        $shop = factory($this->model)->create([
+            'password' => '',
+            'shopify_offline_refresh_token' => null,
+            'shopify_offline_access_token_expires_at' => null,
+        ]);
+
+        $this->assertFalse($shop->hasCorruptExpiringTokenState());
+    }
+
     public function testNamespacingAndFreemium(): void
     {
         $this->app['config']->set('shopify-app.billing_freemium_enabled', true);

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -157,4 +157,52 @@ class UtilTest extends TestCase
             'port mismatch' => ['http://localhost:8080/foo', 'http://localhost', '/'],
         ];
     }
+
+    public function testGetOfflineTokenExcludedShopDomainsEmptyWhenMissing(): void
+    {
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', null);
+
+        $this->assertSame([], Util::getOfflineTokenExcludedShopDomains());
+    }
+
+    public function testGetOfflineTokenExcludedShopDomainsNormalizesArray(): void
+    {
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            ' Placeholder.myshopify.com ',
+            'other.myshopify.com',
+            'placeholder.myshopify.com',
+            '',
+        ]);
+
+        $this->assertSame(
+            ['placeholder.myshopify.com', 'other.myshopify.com'],
+            Util::getOfflineTokenExcludedShopDomains()
+        );
+    }
+
+    public function testGetOfflineTokenExcludedShopDomainsNormalizesCommaString(): void
+    {
+        $this->app['config']->set(
+            'shopify-app.offline_token_excluded_shops',
+            ' Placeholder.myshopify.com , other.myshopify.com,Placeholder.myshopify.com '
+        );
+
+        $this->assertSame(
+            ['placeholder.myshopify.com', 'other.myshopify.com'],
+            Util::getOfflineTokenExcludedShopDomains()
+        );
+    }
+
+    public function testShopIsExcludedFromOfflineTokenLifecycle(): void
+    {
+        $this->app['config']->set('shopify-app.offline_token_excluded_shops', [
+            'placeholder.myshopify.com',
+        ]);
+
+        $excluded = factory($this->model)->create(['name' => 'Placeholder.myshopify.com']);
+        $included = factory($this->model)->create(['name' => 'real-shop.myshopify.com']);
+
+        $this->assertTrue(Util::shopIsExcludedFromOfflineTokenLifecycle($excluded));
+        $this->assertFalse(Util::shopIsExcludedFromOfflineTokenLifecycle($included));
+    }
 }


### PR DESCRIPTION
Adds a couple of exclusions for migrating shops to new tokens:

**Shops with no password:** These rows cannot get a new offline token. Shopify has nothing to exchange. `VerifyShopify` already treats a missing password as “not installed / needs reauth.” Migrate/refresh CLIs skipped those shops, but `$shop->api()` still ran refresh if a leftover refresh token was on the row. That is wasted Shopify calls, failed jobs, and noise.

**Placeholder shops:** App developers can have domains that are not real installs (monitoring, seeds, fixtures). Those still matched “has a password, no refresh token” and got queued for cycle, then 401’d. You can now set these via ENV variable to be skipped. 